### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install test_track_js_client --save
 
 You can find the latest version of the test track JS client [here](https://github.com/Betterment/test_track_js_client/releases).
 
-The test track JS client currently has the following dependencies: `blueimp-md5`, `node-uuid`, `jquery` and `jquery.cookie`.
+The test track JS client currently has the following dependencies: `blueimp-md5`, `uuid`, `jquery` and `jquery.cookie`.
 
 If you're using a fancy build pipeline ([grunt](http://gruntjs.com/), [gulp](http://gulpjs.com/), [broccoli](http://broccolijs.com/), [webpack](https://webpack.github.io/)), then you are all set. If not, you have a few other [options](#alternative-setup) for loading the client into your page.
 
@@ -160,7 +160,7 @@ You can load the dependencies and the library via `script` tags, like this:
 <script type="text/javascript" src="path/to/deps/jquery/dist/jquery.js"></script>
 <script type="text/javascript" src="path/to/deps/jquery.cookie/jquery.cookie.js"></script>
 <script type="text/javascript" src="path/to/deps/blueimp-md5/js/md5.js"></script>
-<script type="text/javascript" src="path/to/deps/node-uuid/uuid.js"></script>
+<script type="text/javascript" src="path/to/deps/uuid/uuid.js"></script>
 <script type="text/javascript" src="path/to/deps/test_track_js_client/dist/testTrack.min.js"></script>
 ```
 
@@ -179,7 +179,7 @@ require.config({
     paths: {
         'jquery': 'path/to/deps/jquery/dist/jquery.js',
         'jquery.cookie': 'path/to/deps/jquery.cookie/jquery.cookie.js',
-        'node-uuid': 'path/to/deps/node-uuid/uuid',
+        'uuid': 'path/to/deps/uuid/uuid',
         'blueimp-md5': 'path/to/deps/blueimp-md5/js/md5'
     }
 });

--- a/dist/testTrack.js
+++ b/dist/testTrack.js
@@ -4,7 +4,7 @@
         // AMD. Register as an anonymous module.
         define(['node-uuid', 'blueimp-md5', 'jquery', 'base-64', 'jquery.cookie'], factory);
     } else if (typeof exports !== 'undefined') {
-        var uuid = require('node-uuid'),
+        var uuid = require('uuid'),
             md5 = require('blueimp-md5'),
             jquery = require('jquery'),
             base64 = require('base-64'),

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "grunt-release-it": "^1.0.0"
   },
   "dependencies": {
+    "base-64": "0.1.0",
     "blueimp-md5": "1.1.1",
-    "node-uuid": "1.4.2",
     "jquery": "~2.1.0",
     "jquery.cookie": "1.4.1",
-    "base-64": "0.1.0"
+    "uuid": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/testTrack.js
+++ b/src/testTrack.js
@@ -4,7 +4,7 @@
         // AMD. Register as an anonymous module.
         define(['node-uuid', 'blueimp-md5', 'jquery', 'base-64', 'jquery.cookie'], factory);
     } else if (typeof exports !== 'undefined') {
-        var uuid = require('node-uuid'),
+        var uuid = require('uuid'),
             md5 = require('blueimp-md5'),
             jquery = require('jquery'),
             base64 = require('base-64'),

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = function(config) {
 
         files: [
             // Dependencies
-            'bower_components/node-uuid/uuid.js',
+            'bower_components/uuid/uuid.js',
             'bower_components/blueimp-md5/js/md5.js',
             'bower_components/jquery/dist/jquery.js',
             'bower_components/jquery.cookie/jquery.cookie.js',


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.