### PR TITLE
Use split registry v2 data structure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/src/abConfiguration.js
+++ b/src/abConfiguration.js
@@ -56,11 +56,11 @@ ABConfiguration.prototype._getNonTrueVariants = function() {
 };
 
 ABConfiguration.prototype._getSplit = function() {
-  return this._splitRegistry ? this._splitRegistry[this._splitName] : null;
+  return this._splitRegistry.getSplit(this._splitName);
 };
 
 ABConfiguration.prototype._getSplitVariants = function() {
-  return this._getSplit() && Object.getOwnPropertyNames(this._getSplit());
+  return this._getSplit() && this._getSplit().getVariants();
 };
 
 export default ABConfiguration;

--- a/src/abConfiguration.test.js
+++ b/src/abConfiguration.test.js
@@ -3,7 +3,7 @@ import Split from './split';
 import SplitRegistry from './splitRegistry';
 import TestTrackConfig from './testTrackConfig';
 import Visitor from './visitor';
-import { mockSplitRegistry } from './test-utils'
+import { mockSplitRegistry } from './test-utils';
 
 jest.mock('./testTrackConfig');
 

--- a/src/abConfiguration.test.js
+++ b/src/abConfiguration.test.js
@@ -1,5 +1,4 @@
 import ABConfiguration from './abConfiguration';
-import Split from './split';
 import SplitRegistry from './splitRegistry';
 import TestTrackConfig from './testTrackConfig';
 import Visitor from './visitor';

--- a/src/abConfiguration.test.js
+++ b/src/abConfiguration.test.js
@@ -1,20 +1,19 @@
 import ABConfiguration from './abConfiguration';
+import Split from './split';
+import SplitRegistry from './splitRegistry';
 import TestTrackConfig from './testTrackConfig';
 import Visitor from './visitor';
+import { mockSplitRegistry } from './test-utils'
 
-jest.mock('./testTrackConfig', () => {
-  return {
-    getSplitRegistry: jest.fn()
-  };
-});
+jest.mock('./testTrackConfig');
 
 describe('ABConfiguration', () => {
   let testContext;
 
   beforeEach(() => {
     testContext = {};
-    TestTrackConfig.getSplitRegistry.mockClear();
-    TestTrackConfig.getSplitRegistry.mockReturnValue({
+
+    TestTrackConfig.getSplitRegistry = mockSplitRegistry({
       element: {
         earth: 25,
         wind: 25,
@@ -95,7 +94,7 @@ describe('ABConfiguration', () => {
     });
 
     it('does not log an error if the split registry is unavailable', () => {
-      TestTrackConfig.getSplitRegistry.mockReturnValue(null);
+      TestTrackConfig.getSplitRegistry.mockReturnValue(new SplitRegistry(null));
 
       var abConfiguration = new ABConfiguration({
         splitName: 'element',
@@ -142,7 +141,7 @@ describe('ABConfiguration', () => {
       });
 
       it('is false when there is no split_registry', () => {
-        TestTrackConfig.getSplitRegistry.mockReturnValue(null);
+        TestTrackConfig.getSplitRegistry.mockReturnValue(new SplitRegistry(null));
 
         var abConfiguration = new ABConfiguration({
           splitName: 'button_color',

--- a/src/session.js
+++ b/src/session.js
@@ -115,7 +115,7 @@ Session.prototype.getPublicAPI = function() {
 
           deferred.resolve({
             visitorId: visitor.getId(),
-            splitRegistry: TestTrackConfig.getSplitRegistry(),
+            splitRegistry: TestTrackConfig.getSplitRegistry().asV1Hash(),
             assignmentRegistry: assignmentRegistry
           });
         });

--- a/src/session.test.js
+++ b/src/session.test.js
@@ -5,7 +5,6 @@ import TestTrackConfig from './testTrackConfig'; // eslint-disable-line no-unuse
 import VaryDSL from './varyDSL'; // eslint-disable-line no-unused-vars
 import * as visitor from './visitor';
 import $ from 'jquery';
-import { mockSplitRegistry } from './test-utils';
 
 jest.mock('./assignmentOverride');
 

--- a/src/session.test.js
+++ b/src/session.test.js
@@ -5,7 +5,7 @@ import TestTrackConfig from './testTrackConfig'; // eslint-disable-line no-unuse
 import VaryDSL from './varyDSL'; // eslint-disable-line no-unused-vars
 import * as visitor from './visitor';
 import $ from 'jquery';
-import { mockSplitRegistry } from './test-utils'
+import { mockSplitRegistry } from './test-utils';
 
 jest.mock('./assignmentOverride');
 

--- a/src/session.test.js
+++ b/src/session.test.js
@@ -5,6 +5,7 @@ import TestTrackConfig from './testTrackConfig'; // eslint-disable-line no-unuse
 import VaryDSL from './varyDSL'; // eslint-disable-line no-unused-vars
 import * as visitor from './visitor';
 import $ from 'jquery';
+import { mockSplitRegistry } from './test-utils'
 
 jest.mock('./assignmentOverride');
 
@@ -16,10 +17,10 @@ jest.mock('./configParser', () => {
           url: 'http://testtrack.dev',
           cookieDomain: '.example.com',
           cookieName: 'custom_cookie_name',
-          registry: {
-            jabba: { cgi: 50, puppet: 50 },
-            wine: { red: 50, white: 25, rose: 25 }
-          },
+          registry: [
+            { name: 'jabba', weights: { cgi: 50, puppet: 50 }, feature_gate: false },
+            { name: 'wine', weights: { red: 50, white: 25, rose: 25 }, feature_gate: false }
+          ],
           assignments: {
             jabba: 'puppet',
             wine: 'rose'

--- a/src/split.js
+++ b/src/split.js
@@ -1,0 +1,23 @@
+var Split = function(name, isFeatureGate, weighting) {
+  this._name = name;
+  this._isFeatureGate = isFeatureGate;
+  this._weighting = weighting;
+};
+
+Split.prototype.getVariants = function() {
+  return Object.keys(this._weighting);
+};
+
+Split.prototype.getWeighting = function() {
+  return this._weighting;
+};
+
+Split.prototype.isFeatureGate = function() {
+  return this._isFeatureGate;
+};
+
+Split.prototype.hasVariant = function(variant) {
+  return variant in this._weighting;
+};
+
+export default Split;

--- a/src/split.js
+++ b/src/split.js
@@ -4,16 +4,20 @@ var Split = function(name, isFeatureGate, weighting) {
   this._weighting = weighting;
 };
 
+Split.prototype.getName = function() {
+  return this._name;
+};
+
+Split.prototype.isFeatureGate = function() {
+  return this._isFeatureGate;
+};
+
 Split.prototype.getVariants = function() {
   return Object.keys(this._weighting);
 };
 
 Split.prototype.getWeighting = function() {
   return this._weighting;
-};
-
-Split.prototype.isFeatureGate = function() {
-  return this._isFeatureGate;
 };
 
 Split.prototype.hasVariant = function(variant) {

--- a/src/split.test.js
+++ b/src/split.test.js
@@ -1,0 +1,27 @@
+import Split from "./split";
+
+describe('Split', () => {
+  let split;
+  beforeEach(() => {
+    split = new Split('split name', true, { foo: 50, bar: 50, baz: 0 })
+  });
+
+  describe('.getVariants()', () => {
+    it('returns all variants', () => {
+      expect(split.getVariants()).toEqual(['foo', 'bar', 'baz']);
+    });
+  });
+
+  describe('.getWeighting()', () => {
+    it('returns the weightings hash', () => {
+      expect(split.getWeighting()).toEqual({ foo: 50, bar: 50, baz: 0 });
+    });
+  });
+
+  describe('.hasVariant()', () => {
+    it('returns whether the variant is defined', () => {
+      expect(split.hasVariant('foo')).toEqual(true);
+      expect(split.hasVariant('buzz')).toEqual(false);
+    });
+  });
+});

--- a/src/split.test.js
+++ b/src/split.test.js
@@ -1,9 +1,9 @@
-import Split from "./split";
+import Split from './split';
 
 describe('Split', () => {
   let split;
   beforeEach(() => {
-    split = new Split('split name', true, { foo: 50, bar: 50, baz: 0 })
+    split = new Split('split name', true, { foo: 50, bar: 50, baz: 0 });
   });
 
   describe('.getVariants()', () => {

--- a/src/splitRegistry.js
+++ b/src/splitRegistry.js
@@ -4,7 +4,7 @@ var SplitRegistry = function(splitArray) {
 };
 
 SplitRegistry.prototype.getSplit = function(splitName) {
-  return !this._offline && this.getSplits()[splitName];
+  return this.getSplits()[splitName];
 };
 
 SplitRegistry.prototype.isUnavailable = function() {
@@ -12,10 +12,6 @@ SplitRegistry.prototype.isUnavailable = function() {
 };
 
 SplitRegistry.prototype.asV1Hash = function() {
-  if (this._offline) {
-    return {};
-  }
-
   var v1Hash = {};
   for (var splitName in this.getSplits()) {
     var split = this._splits[splitName];
@@ -26,6 +22,10 @@ SplitRegistry.prototype.asV1Hash = function() {
 };
 
 SplitRegistry.prototype.getSplits = function() {
+  if (this._offline) {
+    return {};
+  }
+
   if (!this._splits) {
     this._splits = {};
     this._splitArray.forEach(

--- a/src/splitRegistry.js
+++ b/src/splitRegistry.js
@@ -11,7 +11,7 @@ SplitRegistry.prototype.isUnavailable = function() {
   return this._offline;
 };
 
-SplitRegistry.prototype.asV1Hash = function(splitName) {
+SplitRegistry.prototype.asV1Hash = function() {
   if (this._offline) {
     return {};
   }

--- a/src/splitRegistry.js
+++ b/src/splitRegistry.js
@@ -27,13 +27,15 @@ SplitRegistry.prototype.asV1Hash = function(splitName) {
 
 SplitRegistry.prototype.getSplits = function() {
   if (!this._splits) {
-    this._splits = {}
-    this._splitArray.forEach(function(split) {
-      this._splits[split.getName()] = split;
-    }.bind(this));
+    this._splits = {};
+    this._splitArray.forEach(
+      function(split) {
+        this._splits[split.getName()] = split;
+      }.bind(this)
+    );
   }
 
   return this._splits;
-}
+};
 
 export default SplitRegistry;

--- a/src/splitRegistry.js
+++ b/src/splitRegistry.js
@@ -1,24 +1,39 @@
-var SplitRegistry = function(splits) {
-  this._splits = splits;
+var SplitRegistry = function(splitArray) {
+  this._splitArray = splitArray;
+  this._offline = splitArray == null;
 };
 
 SplitRegistry.prototype.getSplit = function(splitName) {
-  return this._splits && this._splits[splitName];
+  return !this._offline && this.getSplits()[splitName];
 };
 
-SplitRegistry.prototype.isUnavailable = function(splitName) {
-  return this._splits === null;
+SplitRegistry.prototype.isUnavailable = function() {
+  return this._offline;
 };
 
 SplitRegistry.prototype.asV1Hash = function(splitName) {
-  var v1Hash = {};
+  if (this._offline) {
+    return {};
+  }
 
-  for (var splitName in this._splits) {
+  var v1Hash = {};
+  for (var splitName in this.getSplits()) {
     var split = this._splits[splitName];
     v1Hash[splitName] = split.getWeighting();
   }
 
   return v1Hash;
 };
+
+SplitRegistry.prototype.getSplits = function() {
+  if (!this._splits) {
+    this._splits = {}
+    this._splitArray.forEach(function(split) {
+      this._splits[split.getName()] = split;
+    }.bind(this));
+  }
+
+  return this._splits;
+}
 
 export default SplitRegistry;

--- a/src/splitRegistry.js
+++ b/src/splitRegistry.js
@@ -1,0 +1,24 @@
+var SplitRegistry = function(splits) {
+  this._splits = splits;
+};
+
+SplitRegistry.prototype.getSplit = function(splitName) {
+  return this._splits && this._splits[splitName];
+};
+
+SplitRegistry.prototype.isUnavailable = function(splitName) {
+  return this._splits === null;
+};
+
+SplitRegistry.prototype.asV1Hash = function(splitName) {
+  var v1Hash = {};
+
+  for (var splitName in this._splits) {
+    var split = this._splits[splitName];
+    v1Hash[splitName] = split.getWeighting();
+  }
+
+  return v1Hash;
+};
+
+export default SplitRegistry;

--- a/src/splitRegistry.test.js
+++ b/src/splitRegistry.test.js
@@ -30,7 +30,7 @@ describe('SplitRegistry', () => {
   });
 
   describe('.asV1Hash()', () => {
-    it('returns whether the split is a feature gate', () => {
+    it('returns a v1 style split registry', () => {
       expect(splitRegistry.asV1Hash()).toEqual({ split1: { foo: 50, bar: 50, baz: 0 }, split2: { up: 50, down: 50 } });
     });
   });

--- a/src/splitRegistry.test.js
+++ b/src/splitRegistry.test.js
@@ -1,5 +1,5 @@
-import Split from "./split";
-import SplitRegistry from "./splitRegistry";
+import Split from './split';
+import SplitRegistry from './splitRegistry';
 
 describe('SplitRegistry', () => {
   let splitRegistry;
@@ -31,7 +31,7 @@ describe('SplitRegistry', () => {
 
   describe('.asV1Hash()', () => {
     it('returns whether the split is a feature gate', () => {
-      expect(splitRegistry.asV1Hash()).toEqual({ split1: { foo: 50, bar: 50, baz: 0 }, split2: { up: 50, down: 50 }});
+      expect(splitRegistry.asV1Hash()).toEqual({ split1: { foo: 50, bar: 50, baz: 0 }, split2: { up: 50, down: 50 } });
     });
   });
 });

--- a/src/splitRegistry.test.js
+++ b/src/splitRegistry.test.js
@@ -1,0 +1,37 @@
+import Split from "./split";
+import SplitRegistry from "./splitRegistry";
+
+describe('SplitRegistry', () => {
+  let splitRegistry;
+  beforeEach(() => {
+    var split1 = new Split('split1', true, { foo: 50, bar: 50, baz: 0 });
+    var split2 = new Split('split2', true, { up: 50, down: 50 });
+    splitRegistry = new SplitRegistry([split1, split2]);
+  });
+
+  describe('.getSplit()', () => {
+    it('returns the split for the given name', () => {
+      let split = splitRegistry.getSplit('split1');
+      expect(split.getName()).toEqual('split1');
+      expect(split.isFeatureGate()).toEqual(true);
+      expect(split.getWeighting()).toEqual({ foo: 50, bar: 50, baz: 0 });
+
+      expect(splitRegistry.getSplit('unknown split')).toEqual(undefined);
+    });
+  });
+
+  describe('.isUnavailable()', () => {
+    it('is unavaible if null is passed in', () => {
+      expect(splitRegistry.isUnavailable()).toEqual(false);
+
+      let unavailableRegistry = new SplitRegistry(null);
+      expect(unavailableRegistry.isUnavailable()).toEqual(true);
+    });
+  });
+
+  describe('.asV1Hash()', () => {
+    it('returns whether the split is a feature gate', () => {
+      expect(splitRegistry.asV1Hash()).toEqual({ split1: { foo: 50, bar: 50, baz: 0 }, split2: { up: 50, down: 50 }});
+    });
+  });
+});

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -11,7 +11,7 @@ function mockSplitRegistry(v1RegistryHash) {
 
   mock.mockReturnValue(new SplitRegistry(splits));
 
-  return mock
+  return mock;
 }
 
-export { mockSplitRegistry }
+export { mockSplitRegistry };

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -3,13 +3,13 @@ import Split from './split';
 
 function mockSplitRegistry(v1RegistryHash) {
   let mock = jest.fn(),
-    registryHash = {};
+    splits = [];
 
   for (var splitName in v1RegistryHash) {
-    registryHash[splitName] = new Split(splitName, false, v1RegistryHash[splitName]);
+    splits.push(new Split(splitName, false, v1RegistryHash[splitName]));
   }
 
-  mock.mockReturnValue(new SplitRegistry(registryHash));
+  mock.mockReturnValue(new SplitRegistry(splits));
 
   return mock
 }

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,0 +1,17 @@
+import SplitRegistry from './splitRegistry';
+import Split from './split';
+
+function mockSplitRegistry(v1RegistryHash) {
+  let mock = jest.fn(),
+    registryHash = {};
+
+  for (var splitName in v1RegistryHash) {
+    registryHash[splitName] = new Split(splitName, false, v1RegistryHash[splitName]);
+  }
+
+  mock.mockReturnValue(new SplitRegistry(registryHash));
+
+  return mock
+}
+
+export { mockSplitRegistry }

--- a/src/testTrackConfig.js
+++ b/src/testTrackConfig.js
@@ -46,11 +46,7 @@ var TestTrackConfig = {
     if (!registry) {
       var splits = [];
       rawRegistry.forEach(function(rawSplit) {
-        splits.push(new Split(
-            rawSplit['name'],
-            rawSplit['feature_gate'],
-            rawSplit['weights']
-          ));
+        splits.push(new Split(rawSplit['name'], rawSplit['feature_gate'], rawSplit['weights']));
       });
       registry = new SplitRegistry(splits);
     }

--- a/src/testTrackConfig.js
+++ b/src/testTrackConfig.js
@@ -1,9 +1,12 @@
 import Assignment from './assignment';
 import ConfigParser from './configParser';
+import Split from './split';
+import SplitRegistry from './splitRegistry';
 
 var DEFAULT_VISITOR_COOKIE_NAME = 'tt_visitor_id',
   config,
   assignments,
+  registry,
   getConfig = function() {
     if (!config) {
       var parser = new ConfigParser();
@@ -29,8 +32,30 @@ var TestTrackConfig = {
     return getConfig().cookieName || DEFAULT_VISITOR_COOKIE_NAME;
   },
 
+  getExperienceSamplingRate: function() {
+    return getConfig().experienceSamplingRate;
+  },
+
   getSplitRegistry: function() {
-    return getConfig().registry;
+    var rawRegistry = getConfig().registry;
+
+    if (!rawRegistry) {
+      return new SplitRegistry(null);
+    }
+
+    if (!registry) {
+      var splits = {};
+      rawRegistry.forEach(function(rawSplit) {
+        splits[rawSplit['name']] = new Split(
+            rawSplit['name'],
+            rawSplit['feature_gate'],
+            rawSplit['weights']
+          );
+      });
+      registry = new SplitRegistry(splits);
+    }
+
+    return registry;
   },
 
   getAssignments: function() {

--- a/src/testTrackConfig.js
+++ b/src/testTrackConfig.js
@@ -44,13 +44,13 @@ var TestTrackConfig = {
     }
 
     if (!registry) {
-      var splits = {};
+      var splits = [];
       rawRegistry.forEach(function(rawSplit) {
-        splits[rawSplit['name']] = new Split(
+        splits.push(new Split(
             rawSplit['name'],
             rawSplit['feature_gate'],
             rawSplit['weights']
-          );
+          ));
       });
       registry = new SplitRegistry(splits);
     }

--- a/src/testTrackConfig.test.js
+++ b/src/testTrackConfig.test.js
@@ -89,4 +89,10 @@ describe('TestTrackConfig', () => {
       ]);
     });
   });
+
+  describe('.getExperienceSamplingRate()', () => {
+    it('returns the provided sampling rate', () => {
+      expect(TestTrackConfig.getExperienceSamplingRate()).toEqual(1);
+    });
+  });
 });

--- a/src/testTrackConfig.test.js
+++ b/src/testTrackConfig.test.js
@@ -12,14 +12,15 @@ jest.mock('./configParser', () => {
           url: 'http://testtrack.dev',
           cookieDomain: '.example.com',
           cookieName: mockCookieName,
-          registry: {
-            jabba: { cgi: 50, puppet: 50 },
-            wine: { red: 50, white: 25, rose: 25 }
-          },
+          registry: [
+            { name: 'jabba', weights: { cgi: 50, puppet: 50 }, feature_gate: true },
+            { name: 'wine', weights: { red: 50, white: 25, rose: 25 }, feature_gate: false }
+          ],
           assignments: {
             jabba: 'puppet',
             wine: 'rose'
-          }
+          },
+          experienceSamplingRate: 1
         };
       }
     };
@@ -68,10 +69,15 @@ describe('TestTrackConfig', () => {
 
   describe('.getSplitRegistry()', () => {
     it('grabs the correct value from the ConfigParser', () => {
-      expect(TestTrackConfig.getSplitRegistry()).toEqual({
-        jabba: { cgi: 50, puppet: 50 },
-        wine: { red: 50, white: 25, rose: 25 }
-      });
+      let splitRegistry = TestTrackConfig.getSplitRegistry();
+
+      let jabba = splitRegistry.getSplit('jabba');
+      expect(jabba.getWeighting()).toEqual({ cgi: 50, puppet: 50 });
+      expect(jabba.isFeatureGate()).toEqual(true);
+
+      let wine = splitRegistry.getSplit('wine');
+      expect(wine.getWeighting()).toEqual({ red: 50, white: 25, rose: 25 });
+      expect(wine.isFeatureGate()).toEqual(false);
     });
   });
 

--- a/src/variantCalculator.js
+++ b/src/variantCalculator.js
@@ -13,7 +13,7 @@ var VariantCalculator = function(options) {
 };
 
 VariantCalculator.prototype.getVariant = function() {
-  if (!TestTrackConfig.getSplitRegistry()) {
+  if (TestTrackConfig.getSplitRegistry().isUnavailable()) {
     return null;
   }
 
@@ -62,15 +62,15 @@ VariantCalculator.prototype.getVariants = function() {
 };
 
 VariantCalculator.prototype.getWeighting = function() {
-  var weighting = TestTrackConfig.getSplitRegistry()[this.splitName];
+  var split = TestTrackConfig.getSplitRegistry().getSplit(this.splitName);
 
-  if (!weighting) {
+  if (!split) {
     var message = 'Unknown split: "' + this.splitName + '"';
     this.visitor.logError(message);
     throw new Error(message);
   }
 
-  return weighting;
+  return split.getWeighting();
 };
 
 export default VariantCalculator;

--- a/src/variantCalculator.test.js
+++ b/src/variantCalculator.test.js
@@ -37,7 +37,7 @@ describe('VariantCalculator', () => {
         miniscule: 19,
         teeny: 0
       }
-    })
+    });
   });
 
   it('requires a visitor', () => {

--- a/src/variantCalculator.test.js
+++ b/src/variantCalculator.test.js
@@ -1,21 +1,10 @@
 import TestTrackConfig from './testTrackConfig';
 import VariantCalculator from './variantCalculator';
 import Visitor from './visitor';
+import { mockSplitRegistry } from './test-utils';
+import SplitRegistry from './splitRegistry';
 
-jest.mock('./testTrackConfig', () => {
-  return {
-    getSplitRegistry: jest.fn().mockReturnValue({
-      logoSize: {
-        extraGiant: 0,
-        giant: 80,
-        huge: 1,
-        leetle: 0,
-        miniscule: 19,
-        teeny: 0
-      }
-    })
-  };
-});
+jest.mock('./testTrackConfig');
 
 describe('VariantCalculator', () => {
   let calculatorOptions;
@@ -38,6 +27,17 @@ describe('VariantCalculator', () => {
     };
 
     testContext.calculator = createCalculator();
+
+    TestTrackConfig.getSplitRegistry = mockSplitRegistry({
+      logoSize: {
+        extraGiant: 0,
+        giant: 80,
+        huge: 1,
+        leetle: 0,
+        miniscule: 19,
+        teeny: 0
+      }
+    })
   });
 
   it('requires a visitor', () => {
@@ -166,13 +166,13 @@ describe('VariantCalculator', () => {
     });
 
     it('returns null if there is no split registry', () => {
-      TestTrackConfig.getSplitRegistry.mockReturnValue(null);
+      TestTrackConfig.getSplitRegistry.mockReturnValue(new SplitRegistry(null));
 
       expect(testContext.calculator.getVariant()).toBeNull();
     });
 
     it('throws an error with an incomplete weighting', () => {
-      TestTrackConfig.getSplitRegistry.mockReturnValue({
+      TestTrackConfig.getSplitRegistry = mockSplitRegistry({
         invalidWeighting: {
           yes: 33,
           no: 33,

--- a/src/variantCalculator.test.js
+++ b/src/variantCalculator.test.js
@@ -1,8 +1,8 @@
+import SplitRegistry from './splitRegistry';
 import TestTrackConfig from './testTrackConfig';
 import VariantCalculator from './variantCalculator';
 import Visitor from './visitor';
 import { mockSplitRegistry } from './test-utils';
-import SplitRegistry from './splitRegistry';
 
 jest.mock('./testTrackConfig');
 

--- a/src/varyDSL.js
+++ b/src/varyDSL.js
@@ -71,7 +71,7 @@ VaryDSL.prototype._assignHandlerToVariant = function(variant, handler) {
 
   variant = variant.toString();
 
-  if (this._getSplit() && !this._getSplit().hasOwnProperty(variant)) {
+  if (this._getSplit() && !this._getSplit().hasVariant(variant)) {
     this._visitor.logError('configures unknown variant ' + variant);
   }
 
@@ -98,11 +98,7 @@ VaryDSL.prototype._validate = function() {
 };
 
 VaryDSL.prototype._getSplit = function() {
-  if (this._splitRegistry) {
-    return this._splitRegistry[this._assignment.getSplitName()];
-  } else {
-    return null;
-  }
+  return this._splitRegistry.getSplit(this._assignment.getSplitName());
 };
 
 VaryDSL.prototype._getVariants = function() {
@@ -112,7 +108,7 @@ VaryDSL.prototype._getVariants = function() {
 VaryDSL.prototype._getMissingVariants = function() {
   var variants = this._getVariants(),
     split = this._getSplit(),
-    splitVariants = Object.getOwnPropertyNames(split),
+    splitVariants = split.getVariants(),
     missingVariants = [];
 
   for (var i = 0; i < splitVariants.length; i++) {

--- a/src/varyDSL.test.js
+++ b/src/varyDSL.test.js
@@ -3,7 +3,7 @@ import SplitRegistry from './splitRegistry';
 import TestTrackConfig from './testTrackConfig';
 import VaryDSL from './varyDSL';
 import Visitor from './visitor';
-import { mockSplitRegistry } from './test-utils'
+import { mockSplitRegistry } from './test-utils';
 
 jest.mock('./testTrackConfig');
 

--- a/src/varyDSL.test.js
+++ b/src/varyDSL.test.js
@@ -1,20 +1,17 @@
 import Assignment from './assignment';
+import SplitRegistry from './splitRegistry';
 import TestTrackConfig from './testTrackConfig';
 import VaryDSL from './varyDSL';
 import Visitor from './visitor';
+import { mockSplitRegistry } from './test-utils'
 
-jest.mock('./testTrackConfig', () => {
-  return {
-    getSplitRegistry: jest.fn()
-  };
-});
+jest.mock('./testTrackConfig');
 
 describe('VaryDSL', () => {
   let testContext;
   beforeEach(() => {
     testContext = {};
-    TestTrackConfig.getSplitRegistry.mockClear();
-    TestTrackConfig.getSplitRegistry.mockReturnValue({
+    TestTrackConfig.getSplitRegistry = mockSplitRegistry({
       element: {
         earth: 25,
         wind: 25,
@@ -103,7 +100,7 @@ describe('VaryDSL', () => {
     });
 
     it('does not log an error when the split registry is unavailable', () => {
-      TestTrackConfig.getSplitRegistry.mockReturnValue(null);
+      TestTrackConfig.getSplitRegistry.mockReturnValue(new SplitRegistry(null));
 
       var vary = new VaryDSL({
         assignment: testContext.assignment,
@@ -116,7 +113,7 @@ describe('VaryDSL', () => {
     });
 
     it('does not log an error for a variant with a 0 weight', () => {
-      TestTrackConfig.getSplitRegistry.mockReturnValue({
+      TestTrackConfig.getSplitRegistry = mockSplitRegistry({
         element: {
           earth: 25,
           wind: 25,
@@ -183,7 +180,7 @@ describe('VaryDSL', () => {
     });
 
     it('does not log an error when the split registry is unavailable', () => {
-      TestTrackConfig.getSplitRegistry.mockReturnValue(null);
+      TestTrackConfig.getSplitRegistry.mockReturnValue(new SplitRegistry(null));
 
       var vary = new VaryDSL({
         assignment: testContext.assignment,
@@ -196,7 +193,7 @@ describe('VaryDSL', () => {
     });
 
     it('does not log an error for a variant with a 0 weight', () => {
-      TestTrackConfig.getSplitRegistry.mockReturnValue({
+      TestTrackConfig.getSplitRegistry = mockSplitRegistry({
         element: {
           earth: 25,
           wind: 25,
@@ -293,7 +290,7 @@ describe('VaryDSL', () => {
     });
 
     it('does not log an error when the split registry is unavailable', () => {
-      TestTrackConfig.getSplitRegistry.mockReturnValue(null);
+      TestTrackConfig.getSplitRegistry.mockReturnValue(new SplitRegistry(null));
 
       var vary = new VaryDSL({
         assignment: testContext.assignment,

--- a/src/visitor.test.js
+++ b/src/visitor.test.js
@@ -6,20 +6,13 @@ import VariantCalculator from './variantCalculator';
 import Visitor from './visitor';
 import $ from 'jquery';
 import uuid from 'uuid';
+import { mockSplitRegistry } from './test-utils'
 
 jest.mock('uuid');
 
 jest.mock('./testTrackConfig', () => {
   return {
     getUrl: () => 'http://testtrack.dev',
-    getSplitRegistry: jest.fn().mockReturnValue({
-      element: {
-        earth: 25,
-        wind: 25,
-        fire: 25,
-        water: 25
-      }
-    }),
     getAssignments: jest.fn()
   };
 });
@@ -51,6 +44,14 @@ describe('Visitor', () => {
     testContext = {};
     testContext.visitor = existingVisitor();
     TestTrackConfig.getAssignments.mockReset();
+    TestTrackConfig.getSplitRegistry = mockSplitRegistry({
+      element: {
+        earth: 25,
+        wind: 25,
+        fire: 25,
+        water: 25
+      }
+    });
   });
 
   function existingVisitor(visitorId) {

--- a/src/visitor.test.js
+++ b/src/visitor.test.js
@@ -6,7 +6,7 @@ import VariantCalculator from './variantCalculator';
 import Visitor from './visitor';
 import $ from 'jquery';
 import uuid from 'uuid';
-import { mockSplitRegistry } from './test-utils'
+import { mockSplitRegistry } from './test-utils';
 
 jest.mock('uuid');
 


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform

This updates the JS client to use the split registry v2 format, which includes the experience sampling rate attribute and encodes the splits as a list of objects which now include whether a split is a feature gate.

This allows the js client to sample feature gate assignment events (coming in a subsequent PR).

The rails client will need to updated to embed the split registry in the new format.