### PR TITLE
Refactor: use jquery.cookie -> js-cookie, node-uuid -> uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "base-64": "0.1.0",
     "blueimp-md5": "2.10.0",
     "jquery": "~3.4.1",
-    "jquery.cookie": "1.4.1",
+    "js-cookie": "^2.2.0",
     "uuid": "^3.3.2"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "blueimp-md5": "2.10.0",
     "jquery": "~3.4.1",
     "jquery.cookie": "1.4.1",
-    "node-uuid": "1.4.8"
+    "uuid": "^3.3.2"
   },
   "files": [
     "dist/*"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import { terser } from 'rollup-plugin-terser';
 export default [
   {
     input: 'src/testTrack.js',
-    external: ['jquery', 'jquery.cookie', 'uuid/v4', 'base-64', 'blueimp-md5'],
+    external: ['jquery', 'js-cookie', 'uuid/v4', 'base-64', 'blueimp-md5'],
     output: {
       file: 'dist/testTrack.js',
       format: 'esm'

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import { terser } from 'rollup-plugin-terser';
 export default [
   {
     input: 'src/testTrack.js',
-    external: ['jquery', 'jquery.cookie', 'uuid', 'base-64', 'blueimp-md5'],
+    external: ['jquery', 'jquery.cookie', 'uuid/v4', 'base-64', 'blueimp-md5'],
     output: {
       file: 'dist/testTrack.js',
       format: 'esm'

--- a/src/session.js
+++ b/src/session.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import 'jquery.cookie';
+import Cookies from 'js-cookie';
 import Assignment from './assignment';
 import AssignmentOverride from './assignmentOverride';
 import TestTrackConfig from './testTrackConfig';
@@ -10,7 +10,7 @@ var Session = function() {
 };
 
 Session.prototype.initialize = function(options) {
-  var visitorId = $.cookie(TestTrackConfig.getCookieName());
+  var visitorId = Cookies.get(TestTrackConfig.getCookieName());
 
   this._visitorDeferred.then(function(visitor) {
     visitor.notifyUnsyncedAssignments();
@@ -89,7 +89,7 @@ Session.prototype.signUp = function(identifierType, value) {
 
 Session.prototype._setCookie = function() {
   this._visitorDeferred.then(function(visitor) {
-    $.cookie(TestTrackConfig.getCookieName(), visitor.getId(), {
+    Cookies.set(TestTrackConfig.getCookieName(), visitor.getId(), {
       expires: 365,
       path: '/',
       domain: TestTrackConfig.getCookieDomain()

--- a/src/session.test.js
+++ b/src/session.test.js
@@ -1,5 +1,6 @@
 import Assignment from './assignment';
 import AssignmentOverride from './assignmentOverride';
+import Cookies from 'js-cookie';
 import Session from './session';
 import TestTrackConfig from './testTrackConfig'; // eslint-disable-line no-unused-vars
 import VaryDSL from './varyDSL'; // eslint-disable-line no-unused-vars
@@ -30,11 +31,13 @@ jest.mock('./configParser', () => {
   });
 });
 
+jest.mock('js-cookie');
+
 describe('Session', () => {
   let testContext;
   beforeEach(() => {
     testContext = {};
-    $.cookie = jest.fn().mockReturnValue('existing_visitor_id');
+    Cookies.get.mockReturnValue('existing_visitor_id');
   });
 
   describe('Cookie behavior', () => {
@@ -52,10 +55,11 @@ describe('Session', () => {
         .then(function() {
           expect(visitor.default.loadVisitor).toHaveBeenCalledWith('existing_visitor_id');
 
-          expect($.cookie).toHaveBeenCalledTimes(2);
-          expect($.cookie).toHaveBeenNthCalledWith(1, 'custom_cookie_name');
+          expect(Cookies.get).toHaveBeenCalledTimes(1);
+          expect(Cookies.get).toHaveBeenCalledWith('custom_cookie_name');
 
-          expect($.cookie).toHaveBeenNthCalledWith(2, 'custom_cookie_name', 'existing_visitor_id', {
+          expect(Cookies.set).toHaveBeenCalledTimes(1);
+          expect(Cookies.set).toHaveBeenCalledWith('custom_cookie_name', 'existing_visitor_id', {
             expires: 365,
             path: '/',
             domain: '.example.com'
@@ -66,7 +70,7 @@ describe('Session', () => {
     });
 
     it('saves the visitor id in a cookie', done => {
-      $.cookie = jest.fn().mockReturnValue(null);
+      Cookies.get.mockReturnValue(null);
 
       var v = new visitor.default({ id: 'generated_visitor_id', assignments: [] });
       visitor.default.loadVisitor = jest.fn().mockReturnValue(
@@ -81,10 +85,11 @@ describe('Session', () => {
         .then(function() {
           expect(visitor.default.loadVisitor).toHaveBeenCalledWith(null);
 
-          expect($.cookie).toHaveBeenCalledTimes(2);
-          expect($.cookie).toHaveBeenNthCalledWith(1, 'custom_cookie_name');
+          expect(Cookies.get).toHaveBeenCalledTimes(1);
+          expect(Cookies.get).toHaveBeenCalledWith('custom_cookie_name');
 
-          expect($.cookie).toHaveBeenNthCalledWith(2, 'custom_cookie_name', 'generated_visitor_id', {
+          expect(Cookies.set).toHaveBeenCalledTimes(1);
+          expect(Cookies.set).toHaveBeenCalledWith('custom_cookie_name', 'generated_visitor_id', {
             expires: 365,
             path: '/',
             domain: '.example.com'
@@ -183,14 +188,14 @@ describe('Session', () => {
 
     describe('#logIn()', () => {
       it('updates the visitor id in the cookie', done => {
-        $.cookie = jest.fn();
+        Cookies.set.mockClear();
 
         testContext.session.logIn('myappdb_user_id', 444).then(
           function() {
             expect(testContext.visitor.linkIdentifier).toHaveBeenCalledTimes(1);
             expect(testContext.visitor.linkIdentifier).toHaveBeenCalledWith('myappdb_user_id', 444);
-            expect($.cookie).toHaveBeenCalledTimes(1);
-            expect($.cookie).toHaveBeenCalledWith('custom_cookie_name', 'other_visitor_id', {
+            expect(Cookies.set).toHaveBeenCalledTimes(1);
+            expect(Cookies.set).toHaveBeenCalledWith('custom_cookie_name', 'other_visitor_id', {
               expires: 365,
               path: '/',
               domain: '.example.com'
@@ -211,14 +216,14 @@ describe('Session', () => {
 
     describe('#signUp()', () => {
       it('updates the visitor id in the cookie', done => {
-        $.cookie = jest.fn();
+        Cookies.set.mockClear();
 
         testContext.session.signUp('myappdb_user_id', 444).then(
           function() {
             expect(testContext.visitor.linkIdentifier).toHaveBeenCalledTimes(1);
             expect(testContext.visitor.linkIdentifier).toHaveBeenCalledWith('myappdb_user_id', 444);
-            expect($.cookie).toHaveBeenCalledTimes(1);
-            expect($.cookie).toHaveBeenCalledWith('custom_cookie_name', 'other_visitor_id', {
+            expect(Cookies.set).toHaveBeenCalledTimes(1);
+            expect(Cookies.set).toHaveBeenCalledWith('custom_cookie_name', 'other_visitor_id', {
               expires: 365,
               path: '/',
               domain: '.example.com'

--- a/src/testTrackConfig.test.js
+++ b/src/testTrackConfig.test.js
@@ -55,15 +55,15 @@ describe('TestTrackConfig', () => {
         expect(TestTrackConfig.getCookieName()).toBe('custom_cookie_name');
       });
     });
+  });
 
-    describe('when there is no configured cookie name', () => {
-      beforeEach(() => {
-        mockCookieName = undefined;
-      });
+  describe('when there is no configured cookie name', () => {
+    beforeEach(() => {
+      mockCookieName = undefined;
+    });
 
-      it('uses the default cookie name', () => {
-        expect(TestTrackConfig.getCookieName()).toBe('tt_visitor_id');
-      });
+    it('uses the default cookie name', () => {
+      expect(TestTrackConfig.getCookieName()).toBe('tt_visitor_id');
     });
   });
 

--- a/src/visitor.js
+++ b/src/visitor.js
@@ -5,7 +5,7 @@ import AssignmentNotification from './assignmentNotification';
 import Identifier from './identifier';
 import MixpanelAnalytics from './mixpanelAnalytics';
 import TestTrackConfig from './testTrackConfig';
-import uuid from 'uuid';
+import uuid from 'uuid/v4';
 import VariantCalculator from './variantCalculator';
 import VaryDSL from './varyDSL';
 
@@ -60,7 +60,7 @@ Visitor.loadVisitor = function(visitorId) {
     }
   } else {
     resolve({
-      id: uuid.v4(),
+      id: uuid(),
       assignments: [],
       ttOffline: false
     });

--- a/src/visitor.test.js
+++ b/src/visitor.test.js
@@ -5,10 +5,10 @@ import TestTrackConfig from './testTrackConfig';
 import VariantCalculator from './variantCalculator';
 import Visitor from './visitor';
 import $ from 'jquery';
-import uuid from 'uuid';
+import uuid from 'uuid/v4';
 import { mockSplitRegistry } from './test-utils';
 
-jest.mock('uuid');
+jest.mock('uuid/v4');
 
 jest.mock('./testTrackConfig', () => {
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3989,11 +3989,6 @@ node-releases@^1.1.19:
   dependencies:
     semver "^5.3.0"
 
-node-uuid@1.4.8:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
-  integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
-
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1815,6 +1815,13 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
+
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
@@ -4268,6 +4275,13 @@ package-json@^6.3.0:
     registry-auth-token "^4.0.0"
     registry-url "^5.0.0"
     semver "^6.2.0"
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
 
 parent-module@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,15 +3417,15 @@ jest@^24.8.0:
     import-local "^2.0.0"
     jest-cli "^24.8.0"
 
-jquery.cookie@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jquery.cookie/-/jquery.cookie-1.4.1.tgz#d63dce209eab691fe63316db08ca9e47e0f9385b"
-  integrity sha1-1j3OIJ6raR/mMxbbCMqeR+D5OFs=
-
 jquery@~3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+
+js-cookie@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
+  integrity sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s=
 
 js-levenshtein@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
I rebased @aburgel's js-cookie branch against the latest `master` branch and opened a PR off my fork until I get push access to the main repo. 

Some test refactoring provided by me. 