### PR TITLE
fix(abConfiguration): splits with one variant return invalid ab variants

### DIFF
--- a/src/abConfiguration.js
+++ b/src/abConfiguration.js
@@ -30,12 +30,12 @@ ABConfiguration.prototype.getVariants = function() {
 // private
 
 ABConfiguration.prototype._getTrueVariant = function() {
-  return this._trueVariant || true;
+  return this._trueVariant || 'true';
 };
 
 ABConfiguration.prototype._getFalseVariant = function() {
   var nonTrueVariants = this._getNonTrueVariants();
-  return nonTrueVariants ? nonTrueVariants.sort()[0] : false;
+  return Array.isArray(nonTrueVariants) && nonTrueVariants.length !== 0 ? nonTrueVariants.sort()[0] : 'false';
 };
 
 ABConfiguration.prototype._getNonTrueVariants = function() {

--- a/src/abConfiguration.test.js
+++ b/src/abConfiguration.test.js
@@ -22,6 +22,9 @@ describe('ABConfiguration', () => {
       button_color: {
         red: 50,
         blue: 50
+      },
+      new_feature: {
+        true: 100
       }
     });
 
@@ -114,7 +117,17 @@ describe('ABConfiguration', () => {
           visitor: testContext.visitor
         });
 
-        expect(abConfiguration.getVariants().true).toBe(true);
+        expect(abConfiguration.getVariants().true).toBe('true');
+      });
+
+      it('is true if only one variant in the split', () => {
+        var abConfiguration = new ABConfiguration({
+          splitName: 'new_feature',
+          trueVariant: null,
+          visitor: testContext.visitor
+        });
+
+        expect(abConfiguration.getVariants().true).toBe('true');
       });
 
       it('is whatever was passed in during instantiation', () => {
@@ -148,7 +161,7 @@ describe('ABConfiguration', () => {
           visitor: testContext.visitor
         });
 
-        expect(abConfiguration.getVariants().false).toBe(false);
+        expect(abConfiguration.getVariants().false).toBe('false');
       });
 
       it('is always the same if the split has more than two variants', () => {
@@ -159,6 +172,16 @@ describe('ABConfiguration', () => {
         });
 
         expect(abConfiguration.getVariants().false).toBe('fire');
+      });
+
+      it('is false if only one variant in the split', () => {
+        var abConfiguration = new ABConfiguration({
+          splitName: 'new_feature',
+          trueVariant: null,
+          visitor: testContext.visitor
+        });
+
+        expect(abConfiguration.getVariants().false).toBe('false');
       });
     });
   });


### PR DESCRIPTION
/domain @chukkwagon @samandmoore @aburgel 
/platform @aburgel @samandmoore 

This PR fixes an issue related to splits with only one variant, most often the case when stubbing splits in test environments. Instead of using booleans as the defaults for AB variants, this PR updates those values to strings "true" and "false" and safely checks for an empty array of non true variants within the ABConfiguration class. 

I tested this patch in `retail`, where we saw the issue, to confirm this works in a production environment. 