### PR TITLE
refactor: use ES6 classes over prototype

### DIFF
--- a/src/abConfiguration.js
+++ b/src/abConfiguration.js
@@ -1,66 +1,66 @@
 import TestTrackConfig from './testTrackConfig';
 
-var ABConfiguration = function(options) {
-  if (!options.splitName) {
-    throw new Error('must provide splitName');
-  } else if (!options.hasOwnProperty('trueVariant')) {
-    throw new Error('must provide trueVariant');
-  } else if (!options.visitor) {
-    throw new Error('must provide visitor');
-  }
-
-  this._splitName = options.splitName;
-  this._trueVariant = options.trueVariant;
-  this._visitor = options.visitor;
-  this._splitRegistry = TestTrackConfig.getSplitRegistry();
-};
-
-ABConfiguration.prototype.getVariants = function() {
-  var splitVariants = this._getSplitVariants();
-  if (splitVariants && splitVariants.length > 2) {
-    this._visitor.logError('A/B for ' + this._splitName + ' configures split with more than 2 variants');
-  }
-
-  return {
-    true: this._getTrueVariant(),
-    false: this._getFalseVariant()
-  };
-};
-
-// private
-
-ABConfiguration.prototype._getTrueVariant = function() {
-  return this._trueVariant || 'true';
-};
-
-ABConfiguration.prototype._getFalseVariant = function() {
-  var nonTrueVariants = this._getNonTrueVariants();
-  return Array.isArray(nonTrueVariants) && nonTrueVariants.length !== 0 ? nonTrueVariants.sort()[0] : 'false';
-};
-
-ABConfiguration.prototype._getNonTrueVariants = function() {
-  var splitVariants = this._getSplitVariants();
-
-  if (splitVariants) {
-    var trueVariant = this._getTrueVariant(),
-      trueVariantIndex = splitVariants.indexOf(trueVariant);
-
-    if (trueVariantIndex !== -1) {
-      splitVariants.splice(trueVariantIndex, 1); // remove the true variant
+class ABConfiguration {
+  constructor(options) {
+    if (!options.splitName) {
+      throw new Error('must provide splitName');
+    } else if (!options.hasOwnProperty('trueVariant')) {
+      throw new Error('must provide trueVariant');
+    } else if (!options.visitor) {
+      throw new Error('must provide visitor');
     }
 
-    return splitVariants;
-  } else {
-    return null;
+    this._splitName = options.splitName;
+    this._trueVariant = options.trueVariant;
+    this._visitor = options.visitor;
+    this._splitRegistry = TestTrackConfig.getSplitRegistry();
   }
-};
 
-ABConfiguration.prototype._getSplit = function() {
-  return this._splitRegistry.getSplit(this._splitName);
-};
+  getVariants() {
+    const splitVariants = this._getSplitVariants();
+    if (splitVariants && splitVariants.length > 2) {
+      this._visitor.logError('A/B for ' + this._splitName + ' configures split with more than 2 variants');
+    }
 
-ABConfiguration.prototype._getSplitVariants = function() {
-  return this._getSplit() && this._getSplit().getVariants();
-};
+    return {
+      true: this._getTrueVariant(),
+      false: this._getFalseVariant()
+    };
+  }
+
+  _getTrueVariant() {
+    return this._trueVariant || 'true';
+  }
+
+  _getFalseVariant() {
+    const nonTrueVariants = this._getNonTrueVariants();
+    return Array.isArray(nonTrueVariants) && nonTrueVariants.length !== 0 ? nonTrueVariants.sort()[0] : 'false';
+  }
+
+  _getNonTrueVariants() {
+    const splitVariants = this._getSplitVariants();
+
+    if (splitVariants) {
+      const trueVariant = this._getTrueVariant();
+      const trueVariantIndex = splitVariants.indexOf(trueVariant);
+
+      if (trueVariantIndex !== -1) {
+        splitVariants.splice(trueVariantIndex, 1); // remove the true variant
+      }
+
+      return splitVariants;
+    } else {
+      return null;
+    }
+  }
+
+  _getSplit() {
+    return this._splitRegistry.getSplit(this._splitName);
+  }
+
+  _getSplitVariants() {
+    return this._getSplit() && this._getSplit().getVariants();
+  }
+}
 
 export default ABConfiguration;

--- a/src/assignment.js
+++ b/src/assignment.js
@@ -1,60 +1,58 @@
-var Assignment = function(options) {
-  if (!options.splitName) {
-    throw new Error('must provide splitName');
-  } else if (!options.hasOwnProperty('variant')) {
-    throw new Error('must provide variant');
-  } else if (!options.hasOwnProperty('isUnsynced')) {
-    throw new Error('must provide isUnsynced');
-  }
-
-  this._splitName = options.splitName;
-  this._variant = options.variant;
-  this._context = options.context;
-  this._isUnsynced = options.isUnsynced;
-};
-
-Assignment.fromJsonArray = function(assignmentsJson) {
-  var assignments = [];
-  for (var i = 0; i < assignmentsJson.length; i++) {
-    assignments.push(
-      new Assignment({
-        splitName: assignmentsJson[i].split_name,
-        variant: assignmentsJson[i].variant,
-        context: assignmentsJson[i].context,
-        isUnsynced: assignmentsJson[i].unsynced
-      })
+class Assignment {
+  static fromJsonArray(assignmentsJson) {
+    return assignmentsJson.map(
+      ({ split_name, variant, context, unsynced }) =>
+        new Assignment({
+          context,
+          variant,
+          splitName: split_name,
+          isUnsynced: unsynced
+        })
     );
   }
 
-  return assignments;
-};
+  constructor(options) {
+    if (!options.splitName) {
+      throw new Error('must provide splitName');
+    } else if (!options.hasOwnProperty('variant')) {
+      throw new Error('must provide variant');
+    } else if (!options.hasOwnProperty('isUnsynced')) {
+      throw new Error('must provide isUnsynced');
+    }
 
-Assignment.prototype.getSplitName = function() {
-  return this._splitName;
-};
+    this._splitName = options.splitName;
+    this._variant = options.variant;
+    this._context = options.context;
+    this._isUnsynced = options.isUnsynced;
+  }
 
-Assignment.prototype.getVariant = function() {
-  return this._variant;
-};
+  getSplitName() {
+    return this._splitName;
+  }
 
-Assignment.prototype.setVariant = function(variant) {
-  this._variant = variant;
-};
+  getVariant() {
+    return this._variant;
+  }
 
-Assignment.prototype.getContext = function() {
-  return this._context;
-};
+  setVariant(variant) {
+    this._variant = variant;
+  }
 
-Assignment.prototype.setContext = function(context) {
-  this._context = context;
-};
+  getContext() {
+    return this._context;
+  }
 
-Assignment.prototype.isUnsynced = function() {
-  return this._isUnsynced;
-};
+  setContext(context) {
+    this._context = context;
+  }
 
-Assignment.prototype.setUnsynced = function(unsynced) {
-  this._isUnsynced = unsynced;
-};
+  isUnsynced() {
+    return this._isUnsynced;
+  }
+
+  setUnsynced(unsynced) {
+    this._isUnsynced = unsynced;
+  }
+}
 
 export default Assignment;

--- a/src/assignmentNotification.js
+++ b/src/assignmentNotification.js
@@ -1,51 +1,52 @@
 import qs from 'qs';
 import client from './api';
 
-const AssignmentNotification = function(options) {
-  options = options || {};
-  this._visitor = options.visitor;
-  this._assignment = options.assignment;
+class AssignmentNotification {
+  constructor(options = {}) {
+    this._visitor = options.visitor;
+    this._assignment = options.assignment;
 
-  if (!this._visitor) {
-    throw new Error('must provide visitor');
-  } else if (!this._assignment) {
-    throw new Error('must provide assignment');
+    if (!this._visitor) {
+      throw new Error('must provide visitor');
+    } else if (!this._assignment) {
+      throw new Error('must provide assignment');
+    }
   }
-};
 
-AssignmentNotification.prototype.send = function() {
-  // FIXME: The current implementation of this requires 2 HTTP requests
-  // to guarantee that the server is notified of the assignment. By decoupling
-  // the assignment notification from the analytics write success we can
-  // bring this down to 1 HTTP request
+  send() {
+    // FIXME: The current implementation of this requires 2 HTTP requests
+    // to guarantee that the server is notified of the assignment. By decoupling
+    // the assignment notification from the analytics write success we can
+    // bring this down to 1 HTTP request
 
-  const firstPersist = this._persistAssignment();
+    const firstPersist = this._persistAssignment();
 
-  const secondPersist = new Promise(resolve => {
-    this._visitor.analytics.trackAssignment(this._visitor.getId(), this._assignment, success =>
-      this._persistAssignment(success ? 'success' : 'failure').then(resolve)
-    );
-  });
-
-  return Promise.all([firstPersist, secondPersist]);
-};
-
-AssignmentNotification.prototype._persistAssignment = function(trackResult) {
-  return client
-    .post(
-      '/v1/assignment_event',
-      qs.stringify({
-        visitor_id: this._visitor.getId(),
-        split_name: this._assignment.getSplitName(),
-        context: this._assignment.getContext(),
-        mixpanel_result: trackResult
-      })
-    )
-    .catch(({ response }) => {
-      this._visitor.logError(
-        `test_track persistAssignment error: ${response.status}, ${response.statusText}, ${response.data}`
+    const secondPersist = new Promise(resolve => {
+      this._visitor.analytics.trackAssignment(this._visitor.getId(), this._assignment, success =>
+        this._persistAssignment(success ? 'success' : 'failure').then(resolve)
       );
     });
-};
+
+    return Promise.all([firstPersist, secondPersist]);
+  }
+
+  _persistAssignment(trackResult) {
+    return client
+      .post(
+        '/v1/assignment_event',
+        qs.stringify({
+          visitor_id: this._visitor.getId(),
+          split_name: this._assignment.getSplitName(),
+          context: this._assignment.getContext(),
+          mixpanel_result: trackResult
+        })
+      )
+      .catch(({ response }) => {
+        this._visitor.logError(
+          `test_track persistAssignment error: ${response.status}, ${response.statusText}, ${response.data}`
+        );
+      });
+  }
+}
 
 export default AssignmentNotification;

--- a/src/assignmentOverride.js
+++ b/src/assignmentOverride.js
@@ -1,47 +1,48 @@
 import qs from 'qs';
 import client from './api';
 
-const AssignmentOverride = function(options) {
-  options = options || {};
-  this._visitor = options.visitor;
-  this._assignment = options.assignment;
-  this._username = options.username;
-  this._password = options.password;
+class AssignmentOverride {
+  constructor(options = {}) {
+    this._visitor = options.visitor;
+    this._assignment = options.assignment;
+    this._username = options.username;
+    this._password = options.password;
 
-  if (!this._visitor) {
-    throw new Error('must provide visitor');
-  } else if (!this._assignment) {
-    throw new Error('must provide assignment');
-  } else if (!this._username) {
-    throw new Error('must provide username');
-  } else if (!this._password) {
-    throw new Error('must provide password');
+    if (!this._visitor) {
+      throw new Error('must provide visitor');
+    } else if (!this._assignment) {
+      throw new Error('must provide assignment');
+    } else if (!this._username) {
+      throw new Error('must provide username');
+    } else if (!this._password) {
+      throw new Error('must provide password');
+    }
   }
-};
 
-AssignmentOverride.prototype.persistAssignment = function() {
-  return client
-    .post(
-      '/v1/assignment_override',
-      qs.stringify({
-        visitor_id: this._visitor.getId(),
-        split_name: this._assignment.getSplitName(),
-        variant: this._assignment.getVariant(),
-        context: this._assignment.getContext(),
-        mixpanel_result: 'success' // we don't want to track overrides
-      }),
-      {
-        auth: {
-          username: this._username,
-          password: this._password
+  persistAssignment() {
+    return client
+      .post(
+        '/v1/assignment_override',
+        qs.stringify({
+          visitor_id: this._visitor.getId(),
+          split_name: this._assignment.getSplitName(),
+          variant: this._assignment.getVariant(),
+          context: this._assignment.getContext(),
+          mixpanel_result: 'success' // we don't want to track overrides
+        }),
+        {
+          auth: {
+            username: this._username,
+            password: this._password
+          }
         }
-      }
-    )
-    .catch(({ response }) => {
-      this._visitor.logError(
-        `test_track persistAssignment error: ${response.status}, ${response.statusText}, ${response.data}`
-      );
-    });
-};
+      )
+      .catch(({ response }) => {
+        this._visitor.logError(
+          `test_track persistAssignment error: ${response.status}, ${response.statusText}, ${response.data}`
+        );
+      });
+  }
+}
 
 export default AssignmentOverride;

--- a/src/configParser.js
+++ b/src/configParser.js
@@ -1,13 +1,13 @@
 import base64 from 'base-64';
 
-var ConfigParser = function() {};
-
-ConfigParser.prototype.getConfig = function() {
-  if (typeof window.atob === 'function') {
-    return JSON.parse(window.atob(window.TT));
-  } else {
-    return JSON.parse(base64.decode(window.TT));
+class ConfigParser {
+  getConfig() {
+    if (typeof window.atob === 'function') {
+      return JSON.parse(window.atob(window.TT));
+    } else {
+      return JSON.parse(base64.decode(window.TT));
+    }
   }
-};
+}
 
 export default ConfigParser;

--- a/src/identifier.js
+++ b/src/identifier.js
@@ -3,36 +3,38 @@ import client from './api';
 import Assignment from './assignment';
 import Visitor from './visitor';
 
-const Identifier = function(options) {
-  this.visitorId = options.visitorId;
-  this.identifierType = options.identifierType;
-  this.value = options.value;
+class Identifier {
+  constructor(options) {
+    this.visitorId = options.visitorId;
+    this.identifierType = options.identifierType;
+    this.value = options.value;
 
-  if (!this.visitorId) {
-    throw new Error('must provide visitorId');
-  } else if (!this.identifierType) {
-    throw new Error('must provide identifierType');
-  } else if (!this.value) {
-    throw new Error('must provide value');
+    if (!this.visitorId) {
+      throw new Error('must provide visitorId');
+    } else if (!this.identifierType) {
+      throw new Error('must provide identifierType');
+    } else if (!this.value) {
+      throw new Error('must provide value');
+    }
   }
-};
 
-Identifier.prototype.save = function() {
-  return client
-    .post(
-      '/v1/identifier',
-      qs.stringify({
-        identifier_type: this.identifierType,
-        value: this.value,
-        visitor_id: this.visitorId
-      })
-    )
-    .then(({ data }) => {
-      return new Visitor({
-        id: data.visitor.id,
-        assignments: Assignment.fromJsonArray(data.visitor.assignments)
+  save() {
+    return client
+      .post(
+        '/v1/identifier',
+        qs.stringify({
+          identifier_type: this.identifierType,
+          value: this.value,
+          visitor_id: this.visitorId
+        })
+      )
+      .then(({ data }) => {
+        return new Visitor({
+          id: data.visitor.id,
+          assignments: Assignment.fromJsonArray(data.visitor.assignments)
+        });
       });
-    });
-};
+  }
+}
 
 export default Identifier;

--- a/src/mixpanelAnalytics.js
+++ b/src/mixpanelAnalytics.js
@@ -1,28 +1,27 @@
-const MixpanelAnalytics = function() {};
+class MixpanelAnalytics {
+  trackAssignment(visitorId, assignment, callback) {
+    const assignmentProperties = {
+      TTVisitorID: visitorId,
+      SplitName: assignment.getSplitName(),
+      SplitVariant: assignment.getVariant(),
+      SplitContext: assignment.getContext()
+    };
 
-MixpanelAnalytics.prototype.trackAssignment = function(visitorId, assignment, callback) {
-  const assignmentProperties = {
-    TTVisitorID: visitorId,
-    SplitName: assignment.getSplitName(),
-    SplitVariant: assignment.getVariant(),
-    SplitContext: assignment.getContext()
-  };
-
-  if (window.mixpanel) {
-    window.mixpanel.track('SplitAssigned', assignmentProperties, callback);
+    if (window.mixpanel) {
+      window.mixpanel.track('SplitAssigned', assignmentProperties, callback);
+    }
   }
-};
 
-MixpanelAnalytics.prototype.identify = function(visitorId) {
-  if (window.mixpanel) {
-    window.mixpanel.identify(visitorId);
+  identify(visitorId) {
+    if (window.mixpanel) {
+      window.mixpanel.identify(visitorId);
+    }
   }
-};
 
-MixpanelAnalytics.prototype.alias = function(visitorId) {
-  if (window.mixpanel) {
-    window.mixpanel.alias(visitorId);
+  alias(visitorId) {
+    if (window.mixpanel) {
+      window.mixpanel.alias(visitorId);
+    }
   }
-};
-
+}
 export default MixpanelAnalytics;

--- a/src/session.js
+++ b/src/session.js
@@ -6,116 +6,116 @@ import Visitor from './visitor';
 
 let loaded = null;
 
-const Session = function() {
-  this._visitorLoaded = new Promise(resolve => {
-    loaded = resolve;
-  });
-};
+class Session {
+  constructor() {
+    this._visitorLoaded = new Promise(resolve => (loaded = resolve));
+  }
 
-Session.prototype.initialize = function(options) {
-  const visitorId = Cookies.get(TestTrackConfig.getCookieName());
+  initialize(options) {
+    const visitorId = Cookies.get(TestTrackConfig.getCookieName());
 
-  Visitor.loadVisitor(visitorId).then(visitor => {
-    if (options && options.analytics) {
-      visitor.setAnalytics(options.analytics);
-    }
+    Visitor.loadVisitor(visitorId).then(visitor => {
+      if (options && options.analytics) {
+        visitor.setAnalytics(options.analytics);
+      }
 
-    if (options && options.errorLogger) {
-      visitor.setErrorLogger(options.errorLogger);
-    }
+      if (options && options.errorLogger) {
+        visitor.setErrorLogger(options.errorLogger);
+      }
 
-    if (options && typeof options.onVisitorLoaded === 'function') {
-      options.onVisitorLoaded.call(null, visitor);
-    }
+      if (options && typeof options.onVisitorLoaded === 'function') {
+        options.onVisitorLoaded.call(null, visitor);
+      }
 
-    visitor.notifyUnsyncedAssignments();
+      visitor.notifyUnsyncedAssignments();
 
-    loaded(visitor);
-  });
-
-  this._setCookie();
-
-  return this._visitorLoaded;
-};
-
-Session.prototype.vary = function(splitName, options) {
-  return this._visitorLoaded.then(function(visitor) {
-    visitor.vary(splitName, options);
-  });
-};
-
-Session.prototype.ab = function(splitName, options) {
-  return this._visitorLoaded.then(function(visitor) {
-    visitor.ab(splitName, options);
-  });
-};
-
-Session.prototype.logIn = function(identifierType, value) {
-  return this._visitorLoaded.then(visitor =>
-    visitor.linkIdentifier(identifierType, value).then(() => {
-      this._setCookie();
-      visitor.analytics.identify(visitor.getId());
-    })
-  );
-};
-
-Session.prototype.signUp = function(identifierType, value) {
-  return this._visitorLoaded.then(visitor =>
-    visitor.linkIdentifier(identifierType, value).then(() => {
-      this._setCookie();
-      visitor.analytics.alias(visitor.getId());
-    })
-  );
-};
-
-Session.prototype._setCookie = function() {
-  return this._visitorLoaded.then(function(visitor) {
-    Cookies.set(TestTrackConfig.getCookieName(), visitor.getId(), {
-      expires: 365,
-      path: '/',
-      domain: TestTrackConfig.getCookieDomain()
+      loaded(visitor);
     });
-  });
-};
 
-Session.prototype.getPublicAPI = function() {
-  return {
-    vary: this.vary.bind(this),
-    ab: this.ab.bind(this),
-    logIn: this.logIn.bind(this),
-    signUp: this.signUp.bind(this),
-    initialize: this.initialize.bind(this),
-    _crx: {
-      loadInfo: () =>
-        this._visitorLoaded.then(function(visitor) {
-          let assignmentRegistry = {};
-          for (var splitName in visitor.getAssignmentRegistry()) {
-            assignmentRegistry[splitName] = visitor.getAssignmentRegistry()[splitName].getVariant();
-          }
+    this._setCookie();
 
-          return {
-            visitorId: visitor.getId(),
-            splitRegistry: TestTrackConfig.getSplitRegistry().asV1Hash(),
-            assignmentRegistry: assignmentRegistry
-          };
-        }),
+    return this._visitorLoaded;
+  }
 
-      persistAssignment: (splitName, variant, username, password) =>
-        this._visitorLoaded.then(function(visitor) {
-          return new AssignmentOverride({
-            visitor,
-            username,
-            password,
-            assignment: new Assignment({
-              splitName,
-              variant,
-              context: 'chrome_extension',
-              isUnsynced: true
-            })
-          }).persistAssignment();
-        })
-    }
-  };
-};
+  vary(splitName, options) {
+    return this._visitorLoaded.then(function(visitor) {
+      visitor.vary(splitName, options);
+    });
+  }
+
+  ab(splitName, options) {
+    return this._visitorLoaded.then(function(visitor) {
+      visitor.ab(splitName, options);
+    });
+  }
+
+  logIn(identifierType, value) {
+    return this._visitorLoaded.then(visitor =>
+      visitor.linkIdentifier(identifierType, value).then(() => {
+        this._setCookie();
+        visitor.analytics.identify(visitor.getId());
+      })
+    );
+  }
+
+  signUp(identifierType, value) {
+    return this._visitorLoaded.then(visitor =>
+      visitor.linkIdentifier(identifierType, value).then(() => {
+        this._setCookie();
+        visitor.analytics.alias(visitor.getId());
+      })
+    );
+  }
+
+  _setCookie() {
+    return this._visitorLoaded.then(function(visitor) {
+      Cookies.set(TestTrackConfig.getCookieName(), visitor.getId(), {
+        expires: 365,
+        path: '/',
+        domain: TestTrackConfig.getCookieDomain()
+      });
+    });
+  }
+
+  getPublicAPI() {
+    return {
+      vary: this.vary.bind(this),
+      ab: this.ab.bind(this),
+      logIn: this.logIn.bind(this),
+      signUp: this.signUp.bind(this),
+      initialize: this.initialize.bind(this),
+      _crx: {
+        loadInfo: () =>
+          this._visitorLoaded.then(function(visitor) {
+            let assignmentRegistry = {};
+            for (var splitName in visitor.getAssignmentRegistry()) {
+              assignmentRegistry[splitName] = visitor.getAssignmentRegistry()[splitName].getVariant();
+            }
+
+            return {
+              visitorId: visitor.getId(),
+              splitRegistry: TestTrackConfig.getSplitRegistry().asV1Hash(),
+              assignmentRegistry: assignmentRegistry
+            };
+          }),
+
+        persistAssignment: (splitName, variant, username, password) =>
+          this._visitorLoaded.then(function(visitor) {
+            return new AssignmentOverride({
+              visitor,
+              username,
+              password,
+              assignment: new Assignment({
+                splitName,
+                variant,
+                context: 'chrome_extension',
+                isUnsynced: true
+              })
+            }).persistAssignment();
+          })
+      }
+    };
+  }
+}
 
 export default Session;

--- a/src/split.js
+++ b/src/split.js
@@ -1,27 +1,29 @@
-var Split = function(name, isFeatureGate, weighting) {
-  this._name = name;
-  this._isFeatureGate = isFeatureGate;
-  this._weighting = weighting;
-};
+class Split {
+  constructor(name, isFeatureGate, weighting) {
+    this._name = name;
+    this._isFeatureGate = isFeatureGate;
+    this._weighting = weighting;
+  }
 
-Split.prototype.getName = function() {
-  return this._name;
-};
+  getName() {
+    return this._name;
+  }
 
-Split.prototype.isFeatureGate = function() {
-  return this._isFeatureGate;
-};
+  isFeatureGate() {
+    return this._isFeatureGate;
+  }
 
-Split.prototype.getVariants = function() {
-  return Object.keys(this._weighting);
-};
+  getVariants() {
+    return Object.keys(this._weighting);
+  }
 
-Split.prototype.getWeighting = function() {
-  return this._weighting;
-};
+  getWeighting() {
+    return this._weighting;
+  }
 
-Split.prototype.hasVariant = function(variant) {
-  return variant in this._weighting;
-};
+  hasVariant(variant) {
+    return variant in this._weighting;
+  }
+}
 
 export default Split;

--- a/src/splitRegistry.js
+++ b/src/splitRegistry.js
@@ -1,41 +1,38 @@
-var SplitRegistry = function(splitArray) {
-  this._splitArray = splitArray;
-  this._loaded = splitArray !== null;
-};
-
-SplitRegistry.prototype.getSplit = function(splitName) {
-  return this.getSplits()[splitName];
-};
-
-SplitRegistry.prototype.isLoaded = function() {
-  return this._loaded;
-};
-
-SplitRegistry.prototype.asV1Hash = function() {
-  var v1Hash = {};
-  for (var splitName in this.getSplits()) {
-    var split = this._splits[splitName];
-    v1Hash[splitName] = split.getWeighting();
+class SplitRegistry {
+  constructor(splitArray) {
+    this._splitArray = splitArray;
+    this._loaded = splitArray !== null;
   }
 
-  return v1Hash;
-};
-
-SplitRegistry.prototype.getSplits = function() {
-  if (!this._loaded) {
-    return {};
+  getSplit(splitName) {
+    return this.getSplits()[splitName];
   }
 
-  if (!this._splits) {
-    this._splits = {};
-    this._splitArray.forEach(
-      function(split) {
-        this._splits[split.getName()] = split;
-      }.bind(this)
-    );
+  isLoaded() {
+    return this._loaded;
   }
 
-  return this._splits;
-};
+  asV1Hash() {
+    const v1Hash = {};
+    for (let splitName in this.getSplits()) {
+      const split = this._splits[splitName];
+      v1Hash[splitName] = split.getWeighting();
+    }
+
+    return v1Hash;
+  }
+
+  getSplits() {
+    if (!this._loaded) {
+      return {};
+    }
+
+    if (!this._splits) {
+      this._splits = this._splitArray.reduce((result, split) => ({ ...result, [split.getName()]: split }), {});
+    }
+
+    return this._splits;
+  }
+}
 
 export default SplitRegistry;

--- a/src/testTrackConfig.js
+++ b/src/testTrackConfig.js
@@ -3,19 +3,20 @@ import ConfigParser from './configParser';
 import Split from './split';
 import SplitRegistry from './splitRegistry';
 
-var DEFAULT_VISITOR_COOKIE_NAME = 'tt_visitor_id',
-  config,
-  assignments,
-  registry,
-  getConfig = function() {
-    if (!config) {
-      var parser = new ConfigParser();
-      config = parser.getConfig();
-    }
-    return config;
-  };
+const DEFAULT_VISITOR_COOKIE_NAME = 'tt_visitor_id';
+let config;
+let assignments;
+let registry;
 
-var TestTrackConfig = {
+const getConfig = function() {
+  if (!config) {
+    const parser = new ConfigParser();
+    config = parser.getConfig();
+  }
+  return config;
+};
+
+const TestTrackConfig = {
   _clear: function() {
     config = null;
   },
@@ -37,15 +38,15 @@ var TestTrackConfig = {
   },
 
   getSplitRegistry: function() {
-    var rawRegistry = getConfig().splits;
+    const rawRegistry = getConfig().splits;
 
     if (!rawRegistry) {
       return new SplitRegistry(null);
     }
 
     if (!registry) {
-      var splits = Object.keys(rawRegistry).map(function(splitName) {
-        var rawSplit = rawRegistry[splitName];
+      const splits = Object.keys(rawRegistry).map(function(splitName) {
+        const rawSplit = rawRegistry[splitName];
         return new Split(splitName, rawSplit['feature_gate'], rawSplit['weights']);
       });
 
@@ -56,7 +57,7 @@ var TestTrackConfig = {
   },
 
   getAssignments: function() {
-    var rawAssignments = getConfig().assignments;
+    const rawAssignments = getConfig().assignments;
 
     if (!rawAssignments) {
       return null;
@@ -64,10 +65,10 @@ var TestTrackConfig = {
 
     if (!assignments) {
       assignments = [];
-      for (var splitName in rawAssignments) {
+      for (let splitName in rawAssignments) {
         assignments.push(
           new Assignment({
-            splitName: splitName,
+            splitName,
             variant: rawAssignments[splitName],
             isUnsynced: false
           })

--- a/src/varyDSL.js
+++ b/src/varyDSL.js
@@ -1,125 +1,107 @@
 import TestTrackConfig from './testTrackConfig';
 
-var VaryDSL = function(options) {
-  if (!options.assignment) {
-    throw new Error('must provide assignment');
-  } else if (!options.visitor) {
-    throw new Error('must provide visitor');
+class VaryDSL {
+  constructor(options) {
+    if (!options.assignment) {
+      throw new Error('must provide assignment');
+    } else if (!options.visitor) {
+      throw new Error('must provide visitor');
+    }
+
+    this._assignment = options.assignment;
+    this._visitor = options.visitor;
+    this._splitRegistry = TestTrackConfig.getSplitRegistry();
+
+    this._variantHandlers = {};
   }
 
-  this._assignment = options.assignment;
-  this._visitor = options.visitor;
-  this._splitRegistry = TestTrackConfig.getSplitRegistry();
+  when(...args) {
+    const handler = typeof args[args.length - 1] === 'function' ? args.pop() : null;
 
-  this._variantHandlers = {};
-};
+    if (args.length === 0) {
+      throw new Error('must provide at least one variant');
+    }
 
-VaryDSL.prototype.when = function() {
-  // these 5 lines are messy because they ensure that we throw the most appropriate error message if when is called incorrectly.
-  // the benefit of this complexity is exercised in the test suite.
-  var argArray = Array.prototype.slice.call(arguments, 0),
-    lastIndex = argArray.length - 1,
-    firstArgIsVariant = typeof argArray[0] !== 'function' && argArray.length > 0,
-    variants = firstArgIsVariant ? argArray.slice(0, Math.max(1, lastIndex)) : [],
-    handler = argArray[lastIndex];
-
-  if (variants.length === 0) {
-    throw new Error('must provide at least one variant');
+    args.forEach(variant => this._assignHandlerToVariant(variant, handler));
   }
 
-  for (var i = 0; i < variants.length; i++) {
-    this._assignHandlerToVariant(variants[i], handler);
-  }
-};
+  default(variant, handler) {
+    if (this._defaultVariant) {
+      throw new Error('must provide exactly one `default`');
+    }
 
-VaryDSL.prototype.default = function(variant, handler) {
-  if (this._defaultVariant) {
-    throw new Error('must provide exactly one `default`');
+    this._defaultVariant = this._assignHandlerToVariant(variant, handler);
   }
 
-  this._defaultVariant = this._assignHandlerToVariant(variant, handler);
-};
+  run() {
+    this._validate();
 
-VaryDSL.prototype.run = function() {
-  this._validate();
+    let chosenHandler;
+    if (this._variantHandlers[this._assignment.getVariant()]) {
+      chosenHandler = this._variantHandlers[this._assignment.getVariant()];
+    } else {
+      chosenHandler = this._variantHandlers[this.getDefaultVariant()];
+      this._defaulted = true;
+    }
 
-  var chosenHandler;
-  if (this._variantHandlers[this._assignment.getVariant()]) {
-    chosenHandler = this._variantHandlers[this._assignment.getVariant()];
-  } else {
-    chosenHandler = this._variantHandlers[this.getDefaultVariant()];
-    this._defaulted = true;
+    chosenHandler();
   }
 
-  chosenHandler();
-};
-
-VaryDSL.prototype.isDefaulted = function() {
-  return this._defaulted || false;
-};
-
-VaryDSL.prototype.getDefaultVariant = function() {
-  return this._defaultVariant;
-};
-
-// private
-
-VaryDSL.prototype._assignHandlerToVariant = function(variant, handler) {
-  if (typeof handler !== 'function') {
-    throw new Error('must provide handler for ' + variant);
+  isDefaulted() {
+    return this._defaulted || false;
   }
 
-  variant = variant.toString();
-
-  if (this._getSplit() && !this._getSplit().hasVariant(variant)) {
-    this._visitor.logError('configures unknown variant ' + variant);
+  getDefaultVariant() {
+    return this._defaultVariant;
   }
 
-  this._variantHandlers[variant] = handler;
+  _assignHandlerToVariant(variant, handler) {
+    if (typeof handler !== 'function') {
+      throw new Error('must provide handler for ' + variant);
+    }
 
-  return variant;
-};
+    variant = variant.toString();
 
-VaryDSL.prototype._validate = function() {
-  if (!this.getDefaultVariant()) {
-    throw new Error('must provide exactly one `default`');
-  } else if (this._getVariants().length < 2) {
-    throw new Error('must provide at least one `when`');
-  } else if (!this._getSplit()) {
-    return;
+    if (this._getSplit() && !this._getSplit().hasVariant(variant)) {
+      this._visitor.logError('configures unknown variant ' + variant);
+    }
+
+    this._variantHandlers[variant] = handler;
+
+    return variant;
   }
 
-  var missingVariants = this._getMissingVariants();
+  _validate() {
+    if (!this.getDefaultVariant()) {
+      throw new Error('must provide exactly one `default`');
+    } else if (this._getVariants().length < 2) {
+      throw new Error('must provide at least one `when`');
+    } else if (!this._getSplit()) {
+      return;
+    }
 
-  if (missingVariants.length > 0) {
-    var missingVariantSentence = missingVariants.join(', ').replace(/, (.+)$/, ' and $1');
-    this._visitor.logError('does not configure variants ' + missingVariantSentence);
-  }
-};
+    const missingVariants = this._getMissingVariants();
 
-VaryDSL.prototype._getSplit = function() {
-  return this._splitRegistry.getSplit(this._assignment.getSplitName());
-};
-
-VaryDSL.prototype._getVariants = function() {
-  return Object.getOwnPropertyNames(this._variantHandlers);
-};
-
-VaryDSL.prototype._getMissingVariants = function() {
-  var variants = this._getVariants(),
-    split = this._getSplit(),
-    splitVariants = split.getVariants(),
-    missingVariants = [];
-
-  for (var i = 0; i < splitVariants.length; i++) {
-    var splitVariant = splitVariants[i];
-
-    if (variants.indexOf(splitVariant) === -1) {
-      missingVariants.push(splitVariant);
+    if (missingVariants.length > 0) {
+      const missingVariantSentence = missingVariants.join(', ').replace(/, (.+)$/, ' and $1');
+      this._visitor.logError('does not configure variants ' + missingVariantSentence);
     }
   }
 
-  return missingVariants;
-};
+  _getSplit() {
+    return this._splitRegistry.getSplit(this._assignment.getSplitName());
+  }
+
+  _getVariants() {
+    return Object.getOwnPropertyNames(this._variantHandlers);
+  }
+
+  _getMissingVariants() {
+    const variants = this._getVariants();
+    const split = this._getSplit();
+    const splitVariants = split.getVariants();
+    return splitVariants.filter(variant => !variants.includes(variant));
+  }
+}
 
 export default VaryDSL;

--- a/src/visitor.js
+++ b/src/visitor.js
@@ -9,252 +9,251 @@ import uuid from 'uuid/v4';
 import VariantCalculator from './variantCalculator';
 import VaryDSL from './varyDSL';
 
-const Visitor = function(options) {
-  options = options || {};
-  this._id = options.id;
-  this._assignments = options.assignments;
-  this._ttOffline = options.ttOffline;
-
-  if (!this._id) {
-    throw new Error('must provide id');
-  } else if (!this._assignments) {
-    throw new Error('must provide assignments');
-  }
-
-  this._errorLogger = function(errorMessage) {
-    window.console.error(errorMessage);
-  };
-
-  this.analytics = new MixpanelAnalytics();
-};
-
-Visitor.loadVisitor = function(visitorId) {
-  if (visitorId) {
-    if (TestTrackConfig.getAssignments()) {
+class Visitor {
+  static loadVisitor(visitorId) {
+    if (visitorId) {
+      if (TestTrackConfig.getAssignments()) {
+        return Promise.resolve(
+          new Visitor({
+            id: visitorId,
+            assignments: TestTrackConfig.getAssignments(),
+            ttOffline: false
+          })
+        );
+      } else {
+        return client
+          .get('/v1/visitors/' + visitorId, { timeout: 5000 })
+          .then(({ data }) => {
+            return new Visitor({
+              id: data.id,
+              assignments: Assignment.fromJsonArray(data.assignments),
+              ttOffline: false
+            });
+          })
+          .catch(() => {
+            return new Visitor({
+              id: visitorId,
+              assignments: [],
+              ttOffline: true
+            });
+          });
+      }
+    } else {
       return Promise.resolve(
         new Visitor({
-          id: visitorId,
-          assignments: TestTrackConfig.getAssignments(),
+          id: uuid(),
+          assignments: [],
           ttOffline: false
         })
       );
-    } else {
-      return client
-        .get('/v1/visitors/' + visitorId, { timeout: 5000 })
-        .then(({ data }) => {
-          return new Visitor({
-            id: data.id,
-            assignments: Assignment.fromJsonArray(data.assignments),
-            ttOffline: false
-          });
-        })
-        .catch(() => {
-          return new Visitor({
-            id: visitorId,
-            assignments: [],
-            ttOffline: true
-          });
-        });
-    }
-  } else {
-    return Promise.resolve(
-      new Visitor({
-        id: uuid(),
-        assignments: [],
-        ttOffline: false
-      })
-    );
-  }
-};
-
-Visitor.prototype.getId = function() {
-  return this._id;
-};
-
-Visitor.prototype.getAssignmentRegistry = function() {
-  if (!this._assignmentRegistry) {
-    this._assignmentRegistry = this._assignments.reduce((registry, assignment) => {
-      return {
-        ...registry,
-        [assignment.getSplitName()]: assignment
-      };
-    }, {});
-  }
-
-  return this._assignmentRegistry;
-};
-
-Visitor.prototype.vary = function(splitName, options) {
-  if (typeof options.variants !== 'object') {
-    throw new Error('must provide variants object to `vary` for ' + splitName);
-  } else if (!options.context) {
-    throw new Error('must provide context to `vary` for ' + splitName);
-  } else if (!options.defaultVariant && options.defaultVariant !== false) {
-    throw new Error('must provide defaultVariant to `vary` for ' + splitName);
-  }
-
-  const defaultVariant = options.defaultVariant.toString();
-  const { variants, context } = options;
-
-  if (!variants.hasOwnProperty(defaultVariant)) {
-    throw new Error('defaultVariant: ' + defaultVariant + ' must be represented in variants object');
-  }
-
-  const assignment = this._getAssignmentFor(splitName, context);
-  const vary = new VaryDSL({
-    assignment,
-    visitor: this
-  });
-
-  for (var variant in variants) {
-    if (variants.hasOwnProperty(variant)) {
-      if (variant === defaultVariant) {
-        vary.default(variant, variants[variant]);
-      } else {
-        vary.when(variant, variants[variant]);
-      }
     }
   }
 
-  vary.run();
+  constructor(options = {}) {
+    this._id = options.id;
+    this._assignments = options.assignments;
+    this._ttOffline = options.ttOffline;
 
-  if (vary.isDefaulted()) {
-    assignment.setVariant(vary.getDefaultVariant());
-    assignment.setUnsynced(true);
-    assignment.setContext(context);
-  }
-
-  this.notifyUnsyncedAssignments();
-};
-
-Visitor.prototype.ab = function(splitName, options) {
-  const abConfiguration = new ABConfiguration({
-    splitName,
-    trueVariant: options.trueVariant,
-    visitor: this
-  });
-  const variants = abConfiguration.getVariants();
-  const variantConfiguration = {};
-
-  variantConfiguration[variants.true] = function() {
-    options.callback(true);
-  };
-
-  variantConfiguration[variants.false] = function() {
-    options.callback(false);
-  };
-
-  this.vary(splitName, {
-    context: options.context,
-    variants: variantConfiguration,
-    defaultVariant: variants.false
-  });
-};
-
-Visitor.prototype.setErrorLogger = function(errorLogger) {
-  if (typeof errorLogger !== 'function') {
-    throw new Error('must provide function for errorLogger');
-  }
-
-  this._errorLogger = errorLogger;
-};
-
-Visitor.prototype.logError = function(errorMessage) {
-  this._errorLogger.call(null, errorMessage); // call with null context to ensure we don't leak the visitor object to the outside world
-};
-
-Visitor.prototype.linkIdentifier = function(identifierType, value) {
-  const identifier = new Identifier({
-    identifierType,
-    value,
-    visitorId: this.getId()
-  });
-
-  return identifier.save().then(otherVisitor => {
-    this._merge(otherVisitor);
-    this.notifyUnsyncedAssignments();
-  });
-};
-
-Visitor.prototype.setAnalytics = function(analytics) {
-  if (typeof analytics !== 'object') {
-    throw new Error('must provide object for setAnalytics');
-  } else {
-    this.analytics = analytics;
-  }
-};
-
-Visitor.prototype.notifyUnsyncedAssignments = function() {
-  this._getUnsyncedAssignments().forEach(this._notify.bind(this));
-};
-
-// private
-
-Visitor.prototype._getUnsyncedAssignments = function() {
-  const registry = this.getAssignmentRegistry();
-  return Object.keys(registry).reduce((result, assignmentName) => {
-    const assignment = registry[assignmentName];
-    if (assignment.isUnsynced()) {
-      result.push(assignment);
-    }
-    return result;
-  }, []);
-};
-
-Visitor.prototype._merge = function(otherVisitor) {
-  const assignmentRegistry = this.getAssignmentRegistry();
-  const otherAssignmentRegistry = otherVisitor.getAssignmentRegistry();
-
-  this._id = otherVisitor.getId();
-
-  Object.assign(assignmentRegistry, otherAssignmentRegistry);
-};
-
-Visitor.prototype._getAssignmentFor = function(splitName, context) {
-  return this.getAssignmentRegistry()[splitName] || this._generateAssignmentFor(splitName, context);
-};
-
-Visitor.prototype._generateAssignmentFor = function(splitName, context) {
-  const variant = new VariantCalculator({
-    visitor: this,
-    splitName: splitName
-  }).getVariant();
-
-  if (!variant) {
-    this._ttOffline = true;
-  }
-
-  const assignment = new Assignment({
-    splitName: splitName,
-    variant: variant,
-    context: context,
-    isUnsynced: true
-  });
-
-  this._assignments.push(assignment);
-
-  // reset derived datastores to trigger rebuilding
-  this._assignmentRegistry = null;
-
-  return assignment;
-};
-
-Visitor.prototype._notify = function(assignment) {
-  try {
-    if (this._ttOffline) {
-      return;
+    if (!this._id) {
+      throw new Error('must provide id');
+    } else if (!this._assignments) {
+      throw new Error('must provide assignments');
     }
 
-    const notification = new AssignmentNotification({
-      visitor: this,
-      assignment
+    this._errorLogger = function(errorMessage) {
+      window.console.error(errorMessage);
+    };
+
+    this.analytics = new MixpanelAnalytics();
+  }
+
+  getId() {
+    return this._id;
+  }
+
+  getAssignmentRegistry() {
+    if (!this._assignmentRegistry) {
+      this._assignmentRegistry = this._assignments.reduce((registry, assignment) => {
+        return {
+          ...registry,
+          [assignment.getSplitName()]: assignment
+        };
+      }, {});
+    }
+
+    return this._assignmentRegistry;
+  }
+
+  vary(splitName, options) {
+    if (typeof options.variants !== 'object') {
+      throw new Error('must provide variants object to `vary` for ' + splitName);
+    } else if (!options.context) {
+      throw new Error('must provide context to `vary` for ' + splitName);
+    } else if (!options.defaultVariant && options.defaultVariant !== false) {
+      throw new Error('must provide defaultVariant to `vary` for ' + splitName);
+    }
+
+    const defaultVariant = options.defaultVariant.toString();
+    const { variants, context } = options;
+
+    if (!variants.hasOwnProperty(defaultVariant)) {
+      throw new Error('defaultVariant: ' + defaultVariant + ' must be represented in variants object');
+    }
+
+    const assignment = this._getAssignmentFor(splitName, context);
+    const vary = new VaryDSL({
+      assignment,
+      visitor: this
     });
 
-    notification.send();
-    assignment.setUnsynced(false);
-  } catch (e) {
-    this.logError('test_track notify error: ' + e);
+    for (let variant in variants) {
+      if (variants.hasOwnProperty(variant)) {
+        if (variant === defaultVariant) {
+          vary.default(variant, variants[variant]);
+        } else {
+          vary.when(variant, variants[variant]);
+        }
+      }
+    }
+
+    vary.run();
+
+    if (vary.isDefaulted()) {
+      assignment.setVariant(vary.getDefaultVariant());
+      assignment.setUnsynced(true);
+      assignment.setContext(context);
+    }
+
+    this.notifyUnsyncedAssignments();
   }
-};
+
+  ab(splitName, options) {
+    const abConfiguration = new ABConfiguration({
+      splitName,
+      trueVariant: options.trueVariant,
+      visitor: this
+    });
+    const variants = abConfiguration.getVariants();
+    const variantConfiguration = {};
+
+    variantConfiguration[variants.true] = function() {
+      options.callback(true);
+    };
+
+    variantConfiguration[variants.false] = function() {
+      options.callback(false);
+    };
+
+    this.vary(splitName, {
+      context: options.context,
+      variants: variantConfiguration,
+      defaultVariant: variants.false
+    });
+  }
+
+  setErrorLogger(errorLogger) {
+    if (typeof errorLogger !== 'function') {
+      throw new Error('must provide function for errorLogger');
+    }
+
+    this._errorLogger = errorLogger;
+  }
+
+  logError(errorMessage) {
+    this._errorLogger.call(null, errorMessage); // call with null context to ensure we don't leak the visitor object to the outside world
+  }
+
+  linkIdentifier(identifierType, value) {
+    const identifier = new Identifier({
+      identifierType,
+      value,
+      visitorId: this.getId()
+    });
+
+    return identifier.save().then(otherVisitor => {
+      this._merge(otherVisitor);
+      this.notifyUnsyncedAssignments();
+    });
+  }
+
+  setAnalytics(analytics) {
+    if (typeof analytics !== 'object') {
+      throw new Error('must provide object for setAnalytics');
+    } else {
+      this.analytics = analytics;
+    }
+  }
+
+  notifyUnsyncedAssignments() {
+    this._getUnsyncedAssignments().forEach(this._notify.bind(this));
+  }
+
+  _getUnsyncedAssignments() {
+    const registry = this.getAssignmentRegistry();
+    return Object.keys(registry).reduce((result, assignmentName) => {
+      const assignment = registry[assignmentName];
+      if (assignment.isUnsynced()) {
+        result.push(assignment);
+      }
+      return result;
+    }, []);
+  }
+
+  _merge(otherVisitor) {
+    const assignmentRegistry = this.getAssignmentRegistry();
+    const otherAssignmentRegistry = otherVisitor.getAssignmentRegistry();
+
+    this._id = otherVisitor.getId();
+
+    Object.assign(assignmentRegistry, otherAssignmentRegistry);
+  }
+
+  _getAssignmentFor(splitName, context) {
+    return this.getAssignmentRegistry()[splitName] || this._generateAssignmentFor(splitName, context);
+  }
+
+  _generateAssignmentFor(splitName, context) {
+    const variant = new VariantCalculator({
+      visitor: this,
+      splitName: splitName
+    }).getVariant();
+
+    if (!variant) {
+      this._ttOffline = true;
+    }
+
+    const assignment = new Assignment({
+      splitName: splitName,
+      variant: variant,
+      context: context,
+      isUnsynced: true
+    });
+
+    this._assignments.push(assignment);
+
+    // reset derived datastores to trigger rebuilding
+    this._assignmentRegistry = null;
+
+    return assignment;
+  }
+
+  _notify(assignment) {
+    try {
+      if (this._ttOffline) {
+        return;
+      }
+
+      const notification = new AssignmentNotification({
+        visitor: this,
+        assignment
+      });
+
+      notification.send();
+      assignment.setUnsynced(false);
+    } catch (e) {
+      this.logError('test_track notify error: ' + e);
+    }
+  }
+}
 
 export default Visitor;


### PR DESCRIPTION
/domain @Betterment/js-platform 
/platform @aburgel @samandmoore 

As part of further refactoring to modernize this library, I've converted the `prototype` usage to ES6 class interface. This should also make it simpler to adopt TypeScript in an upcoming iteration. No test changes were involved in this patch so everything is functionally the same. 