### PR TITLE
refactor: use abab package in place of base-64

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-typescript": "^5.0.2",
-    "@types/base-64": "^0.1.3",
     "@types/blueimp-md5": "^2.7.0",
     "@types/js-cookie": "^2.2.4",
     "@types/qs": "^6.9.0",
@@ -50,8 +49,8 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {
+    "abab": "^2.0.3",
     "axios": "^0.19.0",
-    "base-64": "0.1.0",
     "blueimp-md5": "2.10.0",
     "js-cookie": "^2.2.0",
     "qs": "^6.9.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,7 @@ const customTSConfig = {
 export default [
   {
     input: 'src/testTrack.ts',
-    external: ['js-cookie', 'uuid/v4', 'base-64', 'blueimp-md5', 'axios'],
+    external: ['js-cookie', 'uuid/v4', 'abab', 'blueimp-md5', 'axios'],
     output: {
       dir: 'dist',
       format: 'esm'

--- a/src/configParser.test.js
+++ b/src/configParser.test.js
@@ -18,6 +18,16 @@ describe('ConfigParser', () => {
       });
     });
 
+    describe('window.TT is not decodable', () => {
+      beforeEach(() => {
+        window.TT = 'someNonesense';
+      });
+
+      it('raises an error', () => {
+        expect(testContext.configParser.getConfig).toThrow('Unable to parse configuration');
+      });
+    });
+
     describe('atob is not available', () => {
       beforeEach(() => {
         testContext.originalAtob = window.atob;

--- a/src/configParser.ts
+++ b/src/configParser.ts
@@ -24,20 +24,11 @@ export type Config = {
   url: string;
 };
 
-const fallbackConfig: Config = {
-  assignments: {},
-  cookieDomain: '',
-  cookieName: '',
-  experienceSamplingWeight: 0,
-  splits: {},
-  url: ''
-};
-
 class ConfigParser {
   getConfig(): Config {
     const decodedConfig = atob(window.TT);
     if (decodedConfig) return JSON.parse(decodedConfig);
-    return fallbackConfig;
+    throw new Error('Unable to parse configuration');
   }
 }
 

--- a/src/configParser.ts
+++ b/src/configParser.ts
@@ -1,4 +1,4 @@
-import base64 from 'base-64';
+import { atob } from 'abab';
 
 declare global {
   interface Window {
@@ -24,13 +24,20 @@ export type Config = {
   url: string;
 };
 
+const fallbackConfig: Config = {
+  assignments: {},
+  cookieDomain: '',
+  cookieName: '',
+  experienceSamplingWeight: 0,
+  splits: {},
+  url: ''
+};
+
 class ConfigParser {
   getConfig(): Config {
-    if (typeof window.atob === 'function') {
-      return JSON.parse(window.atob(window.TT));
-    } else {
-      return JSON.parse(base64.decode(window.TT));
-    }
+    const decodedConfig = atob(window.TT);
+    if (decodedConfig) return JSON.parse(decodedConfig);
+    return fallbackConfig;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1090,11 +1090,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/base-64@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@types/base-64/-/base-64-0.1.3.tgz#875320c0d019f576a179324124cdbd5031a411f5"
-  integrity sha512-DJpw7RKNMXygZ0j2xe6ROBqiJUy7JWEItkzOPBzrT35HUWS7VLYyW9XJX8yCCvE2xg8QD7wesvVyXFg8AVHTMA==
-
 "@types/blueimp-md5@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@types/blueimp-md5/-/blueimp-md5-2.7.0.tgz#404222806800478ca2782e8ad46590aba7f14627"
@@ -1192,6 +1187,11 @@ abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
   integrity sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==
+
+abab@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
+  integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
 
 abbrev@1:
   version "1.1.1"
@@ -1460,11 +1460,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
-
-base-64@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
-  integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
 
 base@^0.11.1:
   version "0.11.2"


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform

/task https://app.asana.com/0/786534243298162/1147959806039095

---

`base64` hasn't been published to in 5 years, [`abab`](https://github.com/jsdom/abab) is used by jsdom. `abab` also rescues `InvalidCharacter` errors and returns `null`, so this refactor includes a fallback config if the decoded config is `null`.