### PR TITLE
Fix request error handling

### DIFF
--- a/src/assignmentNotification.test.js
+++ b/src/assignmentNotification.test.js
@@ -105,14 +105,27 @@ describe('AssignmentNotification', () => {
       });
     });
 
-    it('logs an error if the request fails', () => {
+    it('logs an error on an error response', () => {
       testContext.analyticsTrackStub.mockImplementation(track(false));
+      mockClient.reset();
       mockClient.onPost().reply(500, null);
 
       return testContext.notification.send().then(() => {
         expect(testContext.visitor.logError).toHaveBeenCalledTimes(2);
         expect(testContext.visitor.logError).toHaveBeenCalledWith(
-          'test_track persistAssignment error: 500, undefined, null'
+          'test_track persistAssignment response error: 500, undefined, null'
+        );
+      });
+    });
+
+    it('logs an error on an failed request', () => {
+      mockClient.reset();
+      mockClient.onPost().networkError();
+
+      return testContext.notification.send().then(() => {
+        expect(testContext.visitor.logError).toHaveBeenCalledTimes(2);
+        expect(testContext.visitor.logError).toHaveBeenCalledWith(
+          'test_track persistAssignment other error: Error: Network Error'
         );
       });
     });

--- a/src/assignmentNotification.ts
+++ b/src/assignmentNotification.ts
@@ -51,10 +51,13 @@ class AssignmentNotification {
           mixpanel_result: trackResult
         })
       )
-      .catch(({ response }) => {
-        this._visitor.logError(
-          `test_track persistAssignment error: ${response.status}, ${response.statusText}, ${response.data}`
-        );
+      .catch(error => {
+        if (error.response) {
+          const { status, statusText, data } = error.response;
+          this._visitor.logError(`test_track persistAssignment response error: ${status}, ${statusText}, ${data}`);
+        } else {
+          this._visitor.logError(`test_track persistAssignment other error: ${error}`);
+        }
       });
   }
 }

--- a/src/assignmentOverride.test.js
+++ b/src/assignmentOverride.test.js
@@ -93,14 +93,26 @@ describe('AssignmentOverride', () => {
       });
     });
 
-    it('logs an error if the request fails', () => {
+    it('logs an error on an error response', () => {
       mockClient.reset();
       mockClient.onPost().reply(500);
 
       return testContext.override.persistAssignment().then(() => {
         expect(testContext.visitor.logError).toHaveBeenCalledTimes(1);
         expect(testContext.visitor.logError).toHaveBeenCalledWith(
-          'test_track persistAssignment error: 500, undefined, undefined'
+          'test_track persistAssignment response error: 500, undefined, undefined'
+        );
+      });
+    });
+
+    it('logs an error on a network error', () => {
+      mockClient.reset();
+      mockClient.onPost().networkError();
+
+      return testContext.override.persistAssignment().then(() => {
+        expect(testContext.visitor.logError).toHaveBeenCalledTimes(1);
+        expect(testContext.visitor.logError).toHaveBeenCalledWith(
+          'test_track persistAssignment other error: Error: Network Error'
         );
       });
     });

--- a/src/assignmentOverride.ts
+++ b/src/assignmentOverride.ts
@@ -51,10 +51,13 @@ class AssignmentOverride {
           }
         }
       )
-      .catch(({ response }) => {
-        this._visitor.logError(
-          `test_track persistAssignment error: ${response.status}, ${response.statusText}, ${response.data}`
-        );
+      .catch(error => {
+        if (error.response) {
+          const { status, statusText, data } = error.response;
+          this._visitor.logError(`test_track persistAssignment response error: ${status}, ${statusText}, ${data}`);
+        } else {
+          this._visitor.logError(`test_track persistAssignment other error: ${error}`);
+        }
       });
   }
 }


### PR DESCRIPTION
/domain @HipsterBrown @Betterment/test_track_core 
/no-platform

This fixes an exception during error handling that occur when the request fails prior to receiving a response from the server, like timeouts or other errors. At this point, `response` is not available on the error object so you'll see `response is undefined` errors.