### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test_track_js_client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Javascript Client for Test Track",
   "license": "MIT",
   "main": "dist/testTrack.bundle.js",


### PR DESCRIPTION
This should've been bumped when we did a release.