### PR TITLE
fix: update `ab` and `vary` types

### DIFF
--- a/src/abConfiguration.ts
+++ b/src/abConfiguration.ts
@@ -4,13 +4,13 @@ import SplitRegistry from './splitRegistry';
 
 export type ABConfigurationOptions = {
   splitName: string;
-  trueVariant: string | boolean;
+  trueVariant?: string;
   visitor: Visitor;
 };
 
 class ABConfiguration {
   private _splitName: string;
-  private _trueVariant: string | boolean;
+  private _trueVariant?: string;
   private _visitor: Visitor;
   private _splitRegistry: SplitRegistry;
 

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -22,7 +22,7 @@ export type VaryOptions = {
 export type AbOptions = {
   callback: (assignment: boolean | string) => void;
   context: string;
-  trueVariant: boolean | string;
+  trueVariant?: string;
 };
 
 export type VisitorOptions = {

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -16,7 +16,7 @@ type Variants = {
 export type VaryOptions = {
   variants: Variants;
   context: string;
-  defaultVariant: string;
+  defaultVariant: boolean | string;
 };
 
 export type AbOptions = {
@@ -124,7 +124,7 @@ class Visitor {
       throw new Error('must provide variants object to `vary` for ' + splitName);
     } else if (!options.context) {
       throw new Error('must provide context to `vary` for ' + splitName);
-    } else if (!options.defaultVariant) {
+    } else if (!options.defaultVariant && options.defaultVariant !== false) {
       throw new Error('must provide defaultVariant to `vary` for ' + splitName);
     }
 

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -16,7 +16,7 @@ type Variants = {
 export type VaryOptions = {
   variants: Variants;
   context: string;
-  defaultVariant: boolean | string;
+  defaultVariant: string;
 };
 
 export type AbOptions = {
@@ -124,7 +124,7 @@ class Visitor {
       throw new Error('must provide variants object to `vary` for ' + splitName);
     } else if (!options.context) {
       throw new Error('must provide context to `vary` for ' + splitName);
-    } else if (!options.defaultVariant && options.defaultVariant !== false) {
+    } else if (!options.defaultVariant) {
       throw new Error('must provide defaultVariant to `vary` for ' + splitName);
     }
 

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -23,7 +23,6 @@ export type AbOptions = {
   callback: (assignment: boolean | string) => void;
   context: string;
   trueVariant: boolean | string;
-  visitor: Visitor;
 };
 
 export type VisitorOptions = {

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -20,7 +20,7 @@ export type VaryOptions = {
 };
 
 export type AbOptions = {
-  callback: (assignment: boolean | string) => void;
+  callback: (assignment: boolean) => void;
   context: string;
   trueVariant?: string;
 };


### PR DESCRIPTION
Noticed some typing issues when going through `tsc` failures. 