### PR TITLE
chore: bump version to 2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test_track_js_client",
-  "version": "2.1.1",
+  "version": "2.1.3",
   "description": "Javascript Client for Test Track",
   "license": "MIT",
   "main": "dist/testTrack.bundle.js",


### PR DESCRIPTION
I didn't bump the version in `package.json` in #75. However, according to https://www.npmjs.com/package/test_track_js_client this is on 2.1.2 (despite the Github page showing 2.0.0) so I skipped to 2.1.3. LMK if I'm missing something (!)