### PR TITLE
chore: Pin Github Actions to Commit Hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
         name: Install pnpm
         with:
           version: 10
           run_install: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 22.14.0
           cache: 'pnpm'


### PR DESCRIPTION
This PR includes automated changes from running [frizbee](https://github.com/stacklok/frizbee) to pin Github Actions. For more information on what this actually means, take a look at [our documentation on UnpinnedActions](https://github.com/betterment/claws?tab=readme-ov-file#unpinnedactions). Because `frizbee` will be replacing tags with their corresponding commit hash, this change should fundamentally be a no-op. This change just makes our code more explicit about what we're using.

Note that because we're touching Github Workflow files in this PR, there is a chance that [Claws](https://github.com/betterment/claws), our GHA Static Analyzer, will find other issues in those files that were introduced before this PR was created. These findings will need to be addressed before this PR can be merged. 

The Claws documentation has a good list for how to remediate each type of finding, but for brevity, here are some of the commonly seen ones:

* RiskyTriggers: Fires when a workflow has workflow_dispatch or pull_request_target; remediate by leaving comments explaning why, and put an ignore statement ([example](https://github.com/Betterment/retail/blob/92e76923f4e5d51e8386301538e383883cd5eb57/.github/workflows/create_datadog_slo.yml#L2-L4))
* UnsafeCheckout: Fires when a workflow checks out user supplied code; remediate by leaving a comment explaining how the user supplied code is used and confirm it isn't executed ([example](https://github.com/Betterment/linda-test/blob/6cd5954c7c1d2bdb781239b6686b3a5dcbcd6fda/.github/workflows/claws_fork_friendly.yml#L50-L54))

For other findings and how to remediate them, check the [Claws docs!](https://github.com/betterment/claws?tab=readme-ov-file#built-in-rules)

