### PR TITLE
chore: Fix the base URL (backport for v3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@betterment-oss/test-track",
   "type": "module",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Javascript Client for Test Track",
   "license": "MIT",
   "exports": {

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -1,0 +1,18 @@
+import { urlFor } from './index';
+
+describe('urlFor', () => {
+  it('adds the path to the base URL', () => {
+    expect(urlFor('/api/v1/foo', new URL('https://example.org'))).toEqual(new URL('https://example.org/api/v1/foo'));
+    expect(urlFor('/api/v1/foo', new URL('https://example.org/'))).toEqual(new URL('https://example.org/api/v1/foo'));
+  });
+
+  it('preserves the path of the base URL', () => {
+    expect(urlFor('/api/v1/foo', new URL('https://example.org/tt'))).toEqual(
+      new URL('https://example.org/tt/api/v1/foo')
+    );
+
+    expect(urlFor('/api/v1/foo', new URL('https://example.org/tt/'))).toEqual(
+      new URL('https://example.org/tt/api/v1/foo')
+    );
+  });
+});

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,12 +15,18 @@ export * from './types';
 
 export type Client = ReturnType<typeof createClient>;
 
+export function urlFor(path: `/${string}`, base: URL): URL {
+  return new URL(base.pathname.replace(/\/$/, '') + path, base);
+}
+
 export function createClient(config: ClientConfig) {
+  const base = new URL(config.url);
+
   return {
     async getVisitor(visitorId: string): Promise<V1Visitor> {
       const { data } = await request<V1Visitor>({
         method: 'GET',
-        url: new URL(`/api/v1/visitors/${visitorId}`, config.url),
+        url: urlFor(`/api/v1/visitors/${visitorId}`, base),
         timeout: 5000
       });
 
@@ -30,7 +36,7 @@ export function createClient(config: ClientConfig) {
     async postIdentifier(params: V1IdentifierParams): Promise<V1Identifier> {
       const { data } = await request<V1Identifier>({
         method: 'POST',
-        url: new URL('/api/v1/identifier', config.url),
+        url: urlFor('/api/v1/identifier', base),
         body: toSearchParams(params)
       });
 
@@ -40,7 +46,7 @@ export function createClient(config: ClientConfig) {
     async postAssignmentOverride({ auth, ...params }: V1AssignmentOverrideParams): Promise<void> {
       await request({
         method: 'POST',
-        url: new URL('/api/v1/assignment_override', config.url),
+        url: urlFor('/api/v1/assignment_override', base),
         body: toSearchParams(params),
         auth
       });
@@ -49,7 +55,7 @@ export function createClient(config: ClientConfig) {
     async postAssignmentEvent(params: V1AssignmentEventParams): Promise<void> {
       await request({
         method: 'POST',
-        url: new URL('/api/v1/assignment_event', config.url),
+        url: urlFor('/api/v1/assignment_event', base),
         body: toSearchParams(params)
       });
     }


### PR DESCRIPTION
We need to support Test Track hosts like `https://example.org/tt`.

/no-platform