### PR TITLE
fix: update js-cookie (npm) to 3.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "js-cookie": "^2.2.1",
+    "js-cookie": "^3.0.7",
     "js-md5": "^0.8.3",
     "uuid": "^13.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       js-cookie:
-        specifier: ^2.2.1
-        version: 2.2.1
+        specifier: ^3.0.7
+        version: 3.0.8
       js-md5:
         specifier: ^0.8.3
         version: 0.8.3
@@ -1074,8 +1074,8 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
-  js-cookie@2.2.1:
-    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
   js-md5@0.8.3:
     resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
@@ -2506,7 +2506,7 @@ snapshots:
   jiti@2.4.2:
     optional: true
 
-  js-cookie@2.2.1: {}
+  js-cookie@3.0.8: {}
 
   js-md5@0.8.3: {}
 


### PR DESCRIPTION
## Why

Resolves a **high-severity** advisory in `js-cookie`: [GHSA-qjx8-664m-686j](https://github.com/advisories/GHSA-qjx8-664m-686j) (CVE-2026-46625) — *"Per-instance prototype hijack in `assign()` enables cookie-attribute injection."* The vulnerable range is `<= 3.0.5`; this repo was pinned to `js-cookie@2.2.1`, which is in range. The fix is to upgrade to `>= 3.0.7` (resolves to `3.0.8`, with `@types/js-cookie@3.0.6`).

## Major version bump (v2 → v3)

This crosses the v2 → v3 major boundary. The relevant breaking change in [v3.0.0](https://github.com/js-cookie/js-cookie/releases/tag/v3.0.0) is the **removal of built-in JSON support** — `getJSON()` and automatic stringifying in `set()` were dropped in favor of explicit `JSON.stringify` / `JSON.parse`. The other v2 removals (`defaults`, `withConverter`, `noConflict`) are likewise gone.

## Why this repo is unaffected

Our only usage is in `src/storageProvider.ts`, which stores a **plain string** visitor ID:

- `Cookies.get(name)` — unchanged in v3 (string in, string out)
- `Cookies.set(name, visitorId, { expires, path, domain })` — `visitorId` is typed `string`; we never relied on auto-stringify, and never passed an object

We don't use `getJSON()`, auto-stringify, `defaults`, `withConverter`, or `noConflict`. So none of the v3 breaking changes touch our code — **no source or test changes were required.**

## Changes

- `package.json`: `js-cookie` `^2.2.1` → `^3.0.7`
- `pnpm-lock.yaml`: regenerated (`js-cookie@3.0.8`, `@types/js-cookie@3.0.6`)

## Verification

- ✅ `pnpm typecheck`
- ✅ `pnpm test` (70/70)
- ✅ `pnpm lint`
