### PR TITLE
chore: bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@betterment-oss/test-track",
   "type": "module",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Javascript Client for Test Track",
   "license": "MIT",
   "exports": {


### PR DESCRIPTION
Bumps the package version to 4.0.3 to release the js-cookie 3.0.7 security fix merged in #108.